### PR TITLE
Upgrade Guava library to version 32.0.0-jre in CDAP Watchdog

### DIFF
--- a/cdap-data-fabric-tests/src/test/java/io/cdap/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
+++ b/cdap-data-fabric-tests/src/test/java/io/cdap/cdap/data2/transaction/distributed/TransactionServiceClientTest.java
@@ -98,7 +98,7 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
     hConf.setBoolean("fs.hdfs.impl.disable.cache", true);
 
     zkServer = InMemoryZKServer.builder().build();
-    zkServer.startAndWait();
+    zkServer.startAsync().awaitRunning();
 
     CConfiguration cConf = CConfiguration.create();
     // tests should use the current user for HDFS
@@ -121,7 +121,7 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
     server = TransactionServiceTest
         .createTxService(zkServer.getConnectionStr(), Networks.getRandomPort(),
             hConf, tmpFolder.newFolder(), cConf);
-    server.startAndWait();
+    server.startAsync().awaitRunning();
 
     injector = Guice.createInjector(
         new ConfigModule(cConf, hConf),
@@ -150,25 +150,25 @@ public class TransactionServiceClientTest extends TransactionSystemTest {
         new AuthenticationContextModules().getNoOpModule());
 
     zkClient = injector.getInstance(ZKClientService.class);
-    zkClient.startAndWait();
+    zkClient.startAsync().awaitRunning();
 
     txStateStorage = injector.getInstance(TransactionStateStorage.class);
-    txStateStorage.startAndWait();
+    txStateStorage.startAsync().awaitRunning();
   }
 
   @AfterClass
   public static void afterClass() {
     try {
       try {
-        server.stopAndWait();
+        server.stopAsync().awaitTerminated();
         miniDfsCluster.shutdown();
       } finally {
-        zkClient.stopAndWait();
-        txStateStorage.stopAndWait();
+        zkClient.stopAsync().awaitTerminated();
+        txStateStorage.stopAsync().awaitTerminated();
       }
     } finally {
-      zkServer.stopAndWait();
-      txStateStorage.stopAndWait();
+      zkServer.stopAsync().awaitTerminated();
+      txStateStorage.stopAsync().awaitTerminated();
     }
   }
 

--- a/cdap-data-fabric-tests/src/test/java/io/cdap/cdap/data2/transaction/distributed/TransactionServiceTest.java
+++ b/cdap-data-fabric-tests/src/test/java/io/cdap/cdap/data2/transaction/distributed/TransactionServiceTest.java
@@ -91,7 +91,7 @@ public class TransactionServiceTest {
     hConf.setBoolean("fs.hdfs.impl.disable.cache", true);
 
     zkServer = InMemoryZKServer.builder().build();
-    zkServer.startAndWait();
+    zkServer.startAsync().awaitRunning();
   }
 
   @After
@@ -100,7 +100,7 @@ public class TransactionServiceTest {
       miniDfsCluster.shutdown();
     } finally {
       if (zkServer != null) {
-        zkServer.stopAndWait();
+        zkServer.stopAsync().awaitTerminated();
       }
     }
   }
@@ -146,7 +146,7 @@ public class TransactionServiceTest {
     );
 
     ZKClientService zkClient = injector.getInstance(ZKClientService.class);
-    zkClient.startAndWait();
+    zkClient.startAsync().awaitRunning();
 
     try {
       final Table table = createTable("myTable");
@@ -161,7 +161,7 @@ public class TransactionServiceTest {
       TransactionService first = createTxService(zkServer.getConnectionStr(),
           Networks.getRandomPort(),
           hConf, tmpFolder.newFolder());
-      first.startAndWait();
+      first.startAsync().awaitRunning();
       Assert.assertNotNull(txClient.startShort());
       verifyGetAndPut(table, txExecutor, null, "val1");
 
@@ -171,7 +171,7 @@ public class TransactionServiceTest {
           hConf, tmpFolder.newFolder());
       // NOTE: we don't have to wait for start as client should pick it up anyways, but we do wait to ensure
       //       the case with two active is handled well
-      second.startAndWait();
+      second.startAsync().awaitRunning();
       // wait for affect a bit
       TimeUnit.SECONDS.sleep(1);
 
@@ -179,7 +179,7 @@ public class TransactionServiceTest {
       verifyGetAndPut(table, txExecutor, "val1", "val2");
 
       // shutting down the first one is fine: we have another one to pick up the leader role
-      first.stopAndWait();
+      first.stopAsync().awaitTerminated();
 
       Assert.assertNotNull(txClient.startShort());
       verifyGetAndPut(table, txExecutor, "val2", "val3");
@@ -189,21 +189,21 @@ public class TransactionServiceTest {
           Networks.getRandomPort(),
           hConf, tmpFolder.newFolder());
       // NOTE: we don't have to wait for start as client should pick it up anyways
-      third.start();
+      third.startAsync();
       // stopping second one
-      second.stopAndWait();
+      second.stopAsync().awaitTerminated();
 
       Assert.assertNotNull(txClient.startShort());
       verifyGetAndPut(table, txExecutor, "val3", "val4");
 
       // releasing resources
-      third.stop();
+      third.stopAsync().awaitTerminated();
 
     } finally {
       try {
         dropTable("myTable");
       } finally {
-        zkClient.stopAndWait();
+        zkClient.stopAsync().awaitTerminated();
       }
     }
   }
@@ -268,7 +268,7 @@ public class TransactionServiceTest {
             new AuthorizationTestModule(),
             new AuthorizationEnforcementModule().getInMemoryModules(),
             new AuthenticationContextModules().getNoOpModule());
-    injector.getInstance(ZKClientService.class).startAndWait();
+    injector.getInstance(ZKClientService.class).startAsync().awaitRunning();
 
     return injector.getInstance(TransactionService.class);
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data/dataset/SystemDatasetInstantiator.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data/dataset/SystemDatasetInstantiator.java
@@ -16,8 +16,7 @@
 
 package io.cdap.cdap.data.dataset;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
+import com.google.common.base.MoreObjects;
 import io.cdap.cdap.api.data.DatasetInstantiationException;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.DatasetAdmin;
@@ -26,7 +25,6 @@ import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.service.ServiceUnavailableException;
 import io.cdap.cdap.data2.datafabric.dataset.type.ConstantClassLoaderProvider;
 import io.cdap.cdap.data2.datafabric.dataset.type.DatasetClassLoaderProvider;
-import io.cdap.cdap.data2.datafabric.dataset.type.DirectoryClassLoaderProvider;
 import io.cdap.cdap.data2.dataset2.DatasetFramework;
 import io.cdap.cdap.data2.metadata.lineage.AccessType;
 import io.cdap.cdap.proto.id.DatasetId;
@@ -74,7 +72,7 @@ public class SystemDatasetInstantiator implements Closeable {
     this.classLoaderProvider = classLoaderProvider;
     this.datasetFramework = datasetFramework;
     this.parentClassLoader = parentClassLoader == null
-        ? Objects.firstNonNull(Thread.currentThread().getContextClassLoader(),
+        ? MoreObjects.firstNonNull(Thread.currentThread().getContextClassLoader(),
         getClass().getClassLoader()) :
         parentClassLoader;
   }
@@ -110,7 +108,11 @@ public class SystemDatasetInstantiator implements Closeable {
       }
       return dataset;
     } catch (Exception e) {
-      Throwables.propagateIfInstanceOf(e, ServiceUnavailableException.class);
+      if (e instanceof ServiceUnavailableException) {
+
+        throw (ServiceUnavailableException) e;
+
+      }
       throw new DatasetInstantiationException("Failed to access dataset: " + datasetId, e);
     }
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/audit/DefaultAuditPublisher.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/audit/DefaultAuditPublisher.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.data2.audit;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.messaging.TopicNotFoundException;
@@ -69,7 +69,7 @@ public final class DefaultAuditPublisher implements AuditPublisher {
   @Override
   public void publish(MetadataEntity metadataEntity, AuditType auditType,
       AuditPayload auditPayload) {
-    String userId = Objects.firstNonNull(SecurityRequestContext.getUserId(), "");
+    String userId = MoreObjects.firstNonNull(SecurityRequestContext.getUserId(), "");
     AuditMessage auditMessage = new AuditMessage(System.currentTimeMillis(), metadataEntity, userId,
         auditType, auditPayload);
     LOG.trace("Publishing audit message {}", auditMessage);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/DatasetsUtil.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/DatasetsUtil.java
@@ -17,11 +17,9 @@
 package io.cdap.cdap.data2.datafabric.dataset;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.api.data.DatasetInstantiationException;
 import io.cdap.cdap.api.dataset.Dataset;
-import io.cdap.cdap.api.dataset.DatasetDefinition;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.api.dataset.DatasetProperties;
 import io.cdap.cdap.api.dataset.DatasetSpecification;
@@ -128,7 +126,7 @@ public final class DatasetsUtil {
       } catch (DatasetManagementException e) {
         LOG.error("Could NOT add dataset instance {} of type {} with props {}",
             datasetInstanceId, typeName, props, e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFramework.java
@@ -16,8 +16,7 @@
 
 package io.cdap.cdap.data2.datafabric.dataset;
 
-import com.google.common.base.Objects;
-import com.google.common.base.Throwables;
+import com.google.common.base.MoreObjects;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -380,7 +379,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
       DatasetClassLoaderProvider classLoaderProvider) {
 
     if (classLoader == null) {
-      classLoader = Objects.firstNonNull(Thread.currentThread().getContextClassLoader(),
+      classLoader = MoreObjects.firstNonNull(Thread.currentThread().getContextClassLoader(),
           getClass().getClassLoader());
     }
 
@@ -392,7 +391,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
       } catch (IOException e) {
         LOG.error("Was not able to init classloader for module {} while trying to load type {}",
             moduleMeta, datasetTypeMeta, e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
 
       try {
@@ -400,7 +399,7 @@ public class RemoteDatasetFramework implements DatasetFramework {
       } catch (Exception e) {
         LOG.error("Was not able to load dataset module class {} while trying to load type {}",
             moduleMeta.getClassName(), datasetTypeMeta, e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/AuthorizationDatasetTypeService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/AuthorizationDatasetTypeService.java
@@ -56,12 +56,12 @@ public class AuthorizationDatasetTypeService extends AbstractIdleService impleme
 
   @Override
   protected void startUp() throws Exception {
-    delegate.startAndWait();
+    delegate.startAsync().awaitRunning();
   }
 
   @Override
   protected void shutDown() throws Exception {
-    delegate.stopAndWait();
+    delegate.stopAsync().awaitTerminated();
   }
 
   @Override

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetService.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.data2.datafabric.dataset.service;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.AbstractService;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -142,7 +142,7 @@ public class DatasetService extends AbstractService {
   private void startUp() {
     try {
       LOG.info("Starting DatasetService...");
-      typeService.startAndWait();
+      typeService.startAsync().awaitRunning();
       httpService.start();
 
       // setting watch for ops executor service that we need to be running to operate correctly
@@ -155,10 +155,10 @@ public class DatasetService extends AbstractService {
               LOG.info("Discovered {} service", Constants.Service.DATASET_EXECUTOR);
               opExecutorDiscovered.set(serviceDiscovered);
             }
-          }, MoreExecutors.sameThreadExecutor());
+          }, MoreExecutors.directExecutor());
 
       for (DatasetMetricsReporter metricsReporter : metricReporters) {
-        metricsReporter.start();
+        metricsReporter.startAsync();
       }
     } catch (Throwable t) {
       notifyFailed(t);
@@ -234,14 +234,14 @@ public class DatasetService extends AbstractService {
     }
 
     for (DatasetMetricsReporter metricsReporter : metricReporters) {
-      metricsReporter.stop();
+      metricsReporter.stopAsync();
     }
 
     if (opExecutorServiceWatch != null) {
       opExecutorServiceWatch.cancel();
     }
 
-    typeService.stopAndWait();
+    typeService.stopAsync().awaitTerminated();
 
     // Wait for a few seconds for requests to stop
     httpService.stop();
@@ -250,7 +250,7 @@ public class DatasetService extends AbstractService {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("bindAddress", httpService.getBindAddress())
         .toString();
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/DefaultDatasetTypeService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/DefaultDatasetTypeService.java
@@ -18,13 +18,11 @@ package io.cdap.cdap.data2.datafabric.dataset.service;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
-import io.cdap.cdap.api.dataset.module.DatasetType;
 import io.cdap.cdap.common.ConflictException;
 import io.cdap.cdap.common.DatasetModuleCannotBeDeletedException;
 import io.cdap.cdap.common.DatasetModuleNotFoundException;
@@ -108,7 +106,7 @@ public class DefaultDatasetTypeService extends AbstractIdleService implements Da
 
   @Override
   protected void startUp() throws Exception {
-    txClientService.startAndWait();
+    txClientService.startAsync().awaitRunning();
     deleteSystemModules();
     deployDefaultModules();
     if (!extensionModules.isEmpty()) {
@@ -118,7 +116,7 @@ public class DefaultDatasetTypeService extends AbstractIdleService implements Da
 
   @Override
   protected void shutDown() throws Exception {
-    txClientService.stopAndWait();
+    txClientService.stopAsync().awaitTerminated();
   }
 
   /**
@@ -271,8 +269,12 @@ public class DefaultDatasetTypeService extends AbstractIdleService implements Da
       });
     } catch (Exception e) {
       // the only checked exception that the callable throws is IOException
-      Throwables.propagateIfInstanceOf(e, IOException.class);
-      throw Throwables.propagate(e);
+      if (e instanceof IOException) {
+
+        throw (IOException) e;
+
+      }
+      throw new RuntimeException(e);
     }
 
     // verify namespace directory exists
@@ -322,7 +324,9 @@ public class DefaultDatasetTypeService extends AbstractIdleService implements Da
           Locations.mkdirsIfNotExists(archiveDir);
 
           LOG.debug("Copy from {} to {}", uploadedFile, tmpLocation);
-          Files.copy(uploadedFile, Locations.newOutputSupplier(tmpLocation));
+          try (java.io.OutputStream os = tmpLocation.getOutputStream()) {
+            Files.copy(uploadedFile, os);
+          }
 
           // Finally, move archive to final location
           LOG.debug("Storing module {} jar at {}", datasetModuleId, archive);
@@ -383,7 +387,7 @@ public class DefaultDatasetTypeService extends AbstractIdleService implements Da
         LOG.debug("Not adding {} module: it already exists", module.getKey());
       } catch (Throwable th) {
         LOG.error("Failed to add {} module. Aborting.", module.getKey(), th);
-        throw Throwables.propagate(th);
+        throw new RuntimeException(th);
       }
     }
   }
@@ -419,7 +423,7 @@ public class DefaultDatasetTypeService extends AbstractIdleService implements Da
         LOG.debug("Not adding {} extension module: it already exists", module.getKey());
       } catch (Throwable th) {
         LOG.error("Failed to add {} extension module. Aborting.", module.getKey(), th);
-        throw Throwables.propagate(th);
+        throw new RuntimeException(th);
       }
     }
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetAdminService.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.datafabric.dataset.service.executor;
 
-import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.DatasetAdmin;
@@ -138,7 +137,13 @@ public class DatasetAdminService {
                 typeMeta.getName());
           }
         } finally {
-          Closeables.closeQuietly(admin);
+          try {
+
+            admin.close();
+
+          } catch (Exception ignored) {
+
+          }
         }
         return spec1;
       });
@@ -223,7 +228,13 @@ public class DatasetAdminService {
         try {
           admin.drop();
         } finally {
-          Closeables.closeQuietly(admin);
+          try {
+
+            admin.close();
+
+          } catch (Exception ignored) {
+
+          }
         }
         return null;
       });
@@ -267,7 +278,13 @@ public class DatasetAdminService {
       try {
         return operation.perform(admin);
       } finally {
-        Closeables.closeQuietly(admin);
+        try {
+
+          admin.close();
+
+        } catch (Exception ignored) {
+
+        }
       }
     }
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorService.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.data2.datafabric.dataset.service.executor;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -105,7 +105,7 @@ public class DatasetOpExecutorService extends AbstractIdleService {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("bindAddress", httpService.getBindAddress())
         .toString();
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/ImpersonatingDatasetAdmin.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/ImpersonatingDatasetAdmin.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.datafabric.dataset.service.executor;
 
-import com.google.common.base.Throwables;
 import io.cdap.cdap.api.dataset.DatasetAdmin;
 import io.cdap.cdap.proto.id.DatasetId;
 import io.cdap.cdap.security.impersonation.Impersonator;
@@ -114,7 +113,11 @@ class ImpersonatingDatasetAdmin implements DatasetAdmin {
     } catch (IOException ioe) {
       throw ioe;
     } catch (Exception t) {
-      Throwables.propagateIfPossible(t);
+      if (t instanceof RuntimeException) {
+
+        throw (RuntimeException) t;
+
+      }
 
       // since the callables we execute only throw IOException (besides unchecked exceptions),
       // this should never happen
@@ -124,7 +127,7 @@ class ImpersonatingDatasetAdmin implements DatasetAdmin {
       // catch statement. So, no checked exceptions should be wrapped by the following statement. However, we need it
       // because ImpersonationUtils#doAs declares 'throws Exception', because it can throw other checked exceptions
       // in the general case
-      throw Throwables.propagate(t);
+      throw new RuntimeException(t);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/ConstantClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/ConstantClassLoaderProvider.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.data2.datafabric.dataset.type;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import io.cdap.cdap.proto.DatasetModuleMeta;
 import java.io.IOException;
 import javax.annotation.Nullable;
@@ -37,7 +37,7 @@ public class ConstantClassLoaderProvider implements DatasetClassLoaderProvider {
 
   public ConstantClassLoaderProvider(@Nullable ClassLoader classLoader) {
     this.classLoader = classLoader == null
-        ? Objects.firstNonNull(Thread.currentThread().getContextClassLoader(),
+        ? MoreObjects.firstNonNull(Thread.currentThread().getContextClassLoader(),
         getClass().getClassLoader()) :
         classLoader;
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DatasetTypeManager.java
@@ -21,7 +21,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
-import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.DatasetDefinition;
 import io.cdap.cdap.api.dataset.DatasetSpecification;
@@ -145,11 +144,23 @@ public class DatasetTypeManager {
           LOG.error(
               "Could not instantiate instance of dataset module class {} for module {} using jarLocation {}",
               className, datasetModuleId, jarLocation);
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         } finally {
           // Close the ProgramClassLoader
-          Closeables.closeQuietly(cl);
-          Closeables.closeQuietly(classLoaderFolder);
+          try {
+
+            cl.close();
+
+          } catch (Exception ignored) {
+
+          }
+          try {
+
+            classLoaderFolder.close();
+
+          } catch (Exception ignored) {
+
+          }
         }
 
         // 4. determine whether any type were removed from the module, and whether any other modules depend on them
@@ -215,10 +226,10 @@ public class DatasetTypeManager {
           throw new DatasetModuleConflictException(cause.getMessage(), cause);
         }
       }
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     } catch (Exception e) {
       LOG.error("Operation failed", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -342,8 +353,12 @@ public class DatasetTypeManager {
           }
         } catch (Exception e) {
           // the only checked exception the try-catch throws is IOException
-          Throwables.propagateIfInstanceOf(e, IOException.class);
-          throw Throwables.propagate(e);
+          if (e instanceof IOException) {
+
+            throw (IOException) e;
+
+          }
+          throw new RuntimeException(e);
         }
 
         return true;
@@ -354,10 +369,10 @@ public class DatasetTypeManager {
           throw (DatasetModuleConflictException) cause;
         }
       }
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     } catch (Exception e) {
       LOG.error("Operation failed", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -392,7 +407,7 @@ public class DatasetTypeManager {
           });
         } catch (Exception e) {
           // the callable throws no checked exceptions
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         }
 
         // check if there are any instances that use types of these modules?
@@ -420,10 +435,10 @@ public class DatasetTypeManager {
         }
       }
       LOG.error("Failed to delete all modules from namespace {}", namespaceId);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     } catch (Exception e) {
       LOG.error("Operation failed", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -522,7 +537,7 @@ public class DatasetTypeManager {
             // are registered because modules only register their types and but not the module id. So here we
             // just assume that this may happen if the module was already loaded.
           } catch (Exception e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
           }
         }
       }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/datafabric/dataset/type/DirectoryClassLoaderProvider.java
@@ -22,7 +22,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
-import com.google.common.io.Closeables;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.io.Locations;
@@ -95,7 +94,13 @@ public class DirectoryClassLoaderProvider implements DatasetClassLoaderProvider 
     public void onRemoval(RemovalNotification<CacheKey, ClassLoader> notification) {
       ClassLoader cl = notification.getValue();
       if (cl instanceof Closeable) {
-        Closeables.closeQuietly((Closeable) cl);
+        try {
+
+          ((Closeable) cl).close();
+
+        } catch (Exception ignored) {
+
+        }
       }
     }
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DatasetDefinitionRegistries.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DatasetDefinitionRegistries.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.data2.dataset2;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import io.cdap.cdap.api.dataset.module.DatasetDefinitionRegistry;
 import io.cdap.cdap.api.dataset.module.DatasetModule;
 import io.cdap.cdap.common.lang.ClassLoaders;
@@ -35,7 +35,7 @@ public final class DatasetDefinitionRegistries {
     ClassLoader systemClassLoader = DatasetDefinitionRegistries.class.getClassLoader();
 
     // Either uses the given classloader or the system one
-    ClassLoader moduleClassLoader = Objects.firstNonNull(classLoader, systemClassLoader);
+    ClassLoader moduleClassLoader = MoreObjects.firstNonNull(classLoader, systemClassLoader);
 
     Class<? extends DatasetModule> moduleClass;
     try {

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DatasetExistenceVerifier.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DatasetExistenceVerifier.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.dataset2;
 
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
 import io.cdap.cdap.common.DatasetNotFoundException;
@@ -44,7 +43,7 @@ public class DatasetExistenceVerifier implements EntityExistenceVerifier<Dataset
         throw new DatasetNotFoundException(datasetId);
       }
     } catch (DatasetManagementException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DynamicDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/DynamicDatasetCache.java
@@ -16,8 +16,8 @@
 
 package io.cdap.cdap.data2.dataset2;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.io.Closeables;
 import io.cdap.cdap.api.common.RuntimeArguments;
 import io.cdap.cdap.api.common.Scope;
 import io.cdap.cdap.api.data.DatasetContext;
@@ -300,7 +300,13 @@ public abstract class DynamicDatasetCache implements DatasetContext, AutoCloseab
    */
   @Override
   public void close() {
-    Closeables.closeQuietly(instantiator);
+    try {
+
+      instantiator.close();
+
+    } catch (Exception ignored) {
+
+    }
   }
 
   /**
@@ -378,7 +384,7 @@ public abstract class DynamicDatasetCache implements DatasetContext, AutoCloseab
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("namespace", namespace)
           .add("name", name)
           .add("arguments", arguments)

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/InMemoryDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/InMemoryDatasetFramework.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.data2.dataset2;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
-import com.google.common.base.Throwables;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -506,7 +505,7 @@ public class InMemoryDatasetFramework implements DatasetFramework {
         DatasetDefinitionRegistries.register(moduleClassName, classLoader, registry);
       } catch (Exception e) {
         LOG.error("Was not able to load dataset module class {}", moduleClassName, e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/MultiThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/MultiThreadDatasetCache.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.data2.dataset2;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -159,7 +158,7 @@ public class MultiThreadDatasetCache extends DynamicDatasetCache {
       return perThreadMap.get(Thread.currentThread());
     } catch (ExecutionException e) {
       // this should never happen because all we do in the cache loader is crete a new entry.
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/SingleThreadDatasetCache.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/SingleThreadDatasetCache.java
@@ -24,9 +24,7 @@ import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import io.cdap.cdap.api.data.DatasetContext;
 import io.cdap.cdap.api.data.DatasetInstantiationException;
 import io.cdap.cdap.api.dataset.Dataset;
 import io.cdap.cdap.api.dataset.metrics.MeteredDataset;
@@ -367,7 +365,13 @@ public class SingleThreadDatasetCache extends DynamicDatasetCache {
   public void close() {
     for (TransactionAware txAware : extraTxAwares) {
       if (txAware instanceof Closeable) {
-        Closeables.closeQuietly((Closeable) txAware);
+        try {
+
+          ((Closeable) txAware).close();
+
+        } catch (Exception ignored) {
+
+        }
       }
     }
     invalidate();

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/SingleTypeModule.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/SingleTypeModule.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.data2.dataset2;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import io.cdap.cdap.api.dataset.Dataset;
@@ -152,7 +151,7 @@ public class SingleTypeModule implements DatasetModule {
         try {
           return (Dataset) ctor.newInstance(params.toArray());
         } catch (Exception e) {
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         }
       }
     });

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/StaticDatasetFramework.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/StaticDatasetFramework.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.dataset2;
 
-import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.cdap.cdap.api.dataset.DatasetManagementException;
@@ -62,7 +61,7 @@ public class StaticDatasetFramework extends InMemoryDatasetFramework {
         }
       });
     } catch (ExecutionException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -80,7 +79,7 @@ public class StaticDatasetFramework extends InMemoryDatasetFramework {
           });
       return modules;
     } catch (ExecutionException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/file/FileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/file/FileSetDataset.java
@@ -117,7 +117,7 @@ public final class FileSetDataset implements FileSet, DatasetOutputCommitter {
         FileSetProperties.getFilePermissions(spec.getProperties()));
   }
 
-  // similar to Objects.firstNonNull, but we allow both parameters to be null
+  // similar to MoreObjects.firstNonNull, but we allow both parameters to be null
   private <T> T secondIfFirstIsNull(T first, T second) {
     return first != null ? first : second;
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/kv/LevelDBKVTableDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/kv/LevelDBKVTableDefinition.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.dataset2.lib.kv;
 
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.annotation.ReadOnly;
 import io.cdap.cdap.api.annotation.WriteOnly;
@@ -140,7 +139,7 @@ public class LevelDBKVTableDefinition extends
       try {
         return service.getTable(tableName);
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/partitioned/PartitionedFileSetDataset.java
@@ -17,9 +17,9 @@
 package io.cdap.cdap.data2.dataset2.lib.partitioned;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/AbstractTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/AbstractTable.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.data2.dataset2.lib.table;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 import io.cdap.cdap.api.annotation.ReadOnly;
@@ -257,7 +256,7 @@ public abstract class AbstractTable implements Table, TransactionAware {
         return rowReader.read(row, tableSchema);
       } catch (IOException e) {
         LOG.error("Unable to read row.", e);
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/MetadataStoreDataset.java
@@ -17,7 +17,6 @@
 
 package io.cdap.cdap.data2.dataset2.lib.table;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.gson.Gson;
@@ -150,7 +149,7 @@ public class MetadataStoreDataset extends AbstractDataset {
         return deserialize(id, value, typeOfT);
       }
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -460,7 +459,7 @@ public class MetadataStoreDataset extends AbstractDataset {
         }
       }
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -473,7 +472,7 @@ public class MetadataStoreDataset extends AbstractDataset {
     try {
       table.delete(id.getKey(), COLUMN);
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -487,7 +486,7 @@ public class MetadataStoreDataset extends AbstractDataset {
     try {
       table.put(new Put(id.getKey()).add(COLUMN, serialize(value)));
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -501,7 +500,7 @@ public class MetadataStoreDataset extends AbstractDataset {
     try {
       table.increment(id.getKey(), COLUMN, amount);
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -531,7 +530,7 @@ public class MetadataStoreDataset extends AbstractDataset {
         return map;
       }
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -566,7 +565,7 @@ public class MetadataStoreDataset extends AbstractDataset {
         return map;
       }
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableCore.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.dataset2.lib.table.leveldb;
 
-import com.google.common.base.Throwables;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.dataset.table.Result;
 import io.cdap.cdap.api.dataset.table.Row;
@@ -618,7 +617,7 @@ public class LevelDBTableCore {
           return new Result(result.getFirst(), result.getSecond());
         }
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }
 

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/table/leveldb/LevelDBTableService.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -212,7 +211,13 @@ public class LevelDBTableService implements AutoCloseable {
    */
   public void clearTables() {
     for (DB entries : tables.values()) {
-      Closeables.closeQuietly(entries);
+      try {
+
+        entries.close();
+
+      } catch (Exception ignored) {
+
+      }
     }
     tables.clear();
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/EntityTable.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/dataset2/lib/timeseries/EntityTable.java
@@ -15,7 +15,7 @@
  */
 package io.cdap.cdap.data2.dataset2.lib.timeseries;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -293,7 +293,7 @@ public final class EntityTable implements Closeable {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
           .add("type", type)
           .add("name", name)
           .toString();

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/queue/ConsumerConfig.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/queue/ConsumerConfig.java
@@ -15,6 +15,7 @@
  */
 package io.cdap.cdap.data2.queue;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -52,7 +53,7 @@ public final class ConsumerConfig extends ConsumerGroupConfig {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("groupId", getGroupId())
         .add("instanceId", instanceId)
         .add("groupSize", getGroupSize())

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/queue/ConsumerGroupConfig.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/queue/ConsumerGroupConfig.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.data2.queue;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -58,7 +59,7 @@ public class ConsumerGroupConfig {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("groupId", groupId)
         .add("groupSize", groupSize)
         .add("dequeueStrategy", dequeueStrategy)

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/queue/DequeueResult.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/queue/DequeueResult.java
@@ -16,7 +16,7 @@
 package io.cdap.cdap.data2.queue;
 
 
-import com.google.common.collect.Iterators;
+import java.util.Collections;
 import java.util.Iterator;
 
 
@@ -88,7 +88,7 @@ public interface DequeueResult<T> extends Iterable<T> {
 
         @Override
         public Iterator<T> iterator() {
-          return Iterators.emptyIterator();
+          return Collections.emptyIterator();
         }
       };
     }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/transaction/DynamicTransactionExecutor.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/data2/transaction/DynamicTransactionExecutor.java
@@ -20,7 +20,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.apache.tephra.AbstractTransactionExecutor;
-import org.apache.tephra.RetryOnConflictStrategy;
 import org.apache.tephra.RetryStrategies;
 import org.apache.tephra.RetryStrategy;
 import org.apache.tephra.TransactionContext;
@@ -48,7 +47,7 @@ public class DynamicTransactionExecutor extends AbstractTransactionExecutor {
 
   public DynamicTransactionExecutor(TransactionContextFactory txContextFactory,
       RetryStrategy retryStrategy) {
-    super(MoreExecutors.sameThreadExecutor());
+    super(MoreExecutors.newDirectExecutorService());
     this.txContextFactory = txContextFactory;
     this.retryStrategy = retryStrategy;
   }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableDatasetDefinition.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableDatasetDefinition.java
@@ -83,7 +83,7 @@ public class NoSqlStructuredTableDatasetDefinition implements DatasetDefinition 
               datasetContext, spec, arguments, classLoader));
     } catch (Exception e) {
       Throwables.propagateIfPossible(e, IOException.class);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStorageProvider.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/data/sql/PostgreSqlStorageProvider.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.spi.data.sql;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -197,7 +196,7 @@ public class PostgreSqlStorageProvider implements StorageProvider {
       JDBCDriverShim driverShim = new JDBCDriverShim(driver);
       DriverManager.registerDriver(driverShim);
     } catch (InstantiationException | IllegalAccessException | ClassNotFoundException | SQLException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     LOG.info("Successfully loaded {} from {}", driverName, driverExtensionPath);

--- a/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/dataset/SearchHelper.java
+++ b/cdap-data-fabric/src/main/java/io/cdap/cdap/spi/metadata/dataset/SearchHelper.java
@@ -22,7 +22,6 @@ import static io.cdap.cdap.api.metadata.MetadataScope.USER;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
 import io.cdap.cdap.api.Transactional;
@@ -155,7 +154,7 @@ public class SearchHelper {
           dataset = metaDatasetDefinition.getDataset(
               SYSTEM_CONTEXT, datasetSpecs.get(scope), Collections.emptyMap(), null);
         } catch (IOException e) {
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         }
         datasets.put(scope, dataset);
         txContext.addTransactionAware(dataset);
@@ -198,7 +197,13 @@ public class SearchHelper {
     @Override
     public void close() {
       for (String scope : datasets.keySet()) {
-        Closeables.closeQuietly(datasets.get(scope));
+        try {
+
+          datasets.get(scope).close();
+
+        } catch (Exception ignored) {
+
+        }
       }
       datasets.clear();
     }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/api/dataset/lib/ReflectionTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/api/dataset/lib/ReflectionTableTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.api.dataset.lib;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.reflect.TypeToken;
 import io.cdap.cdap.api.common.Bytes;
@@ -144,7 +145,7 @@ public class ReflectionTableTest {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
+      return MoreObjects.toStringHelper(this)
         .add("firstName", firstName)
         .add("lastName", lastName)
         .add("id", id)

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/api/dataset/lib/TimeseriesTableScannerTest.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.api.dataset.lib;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -263,7 +263,7 @@ public class TimeseriesTableScannerTest {
 
     @Override
     public String toString() {
-      return Objects.toStringHelper(Fact.class)
+      return MoreObjects.toStringHelper(Fact.class)
         .add("ts", ts)
         .add("dimensions", dimensions)
         .toString();

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/RemoteDatasetFrameworkTest.java
@@ -131,7 +131,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
 
     // Tx Manager to support working with datasets
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     TransactionRunner transactionRunner = injector.getInstance(TransactionRunner.class);
     StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
     StoreDefinition.createAllTables(structuredTableAdmin);
@@ -155,7 +155,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
       ImmutableSet.of(new DatasetAdminOpHTTPHandler(datasetAdminService));
     opExecutorService = new DatasetOpExecutorService(cConf, SConfiguration.create(),
                                                      discoveryService, commonNettyHttpServiceFactory, handlers);
-    opExecutorService.startAndWait();
+    opExecutorService.startAsync().awaitRunning();
 
     AccessEnforcer accessEnforcer = injector.getInstance(AccessEnforcer.class);
 
@@ -182,7 +182,7 @@ public class RemoteDatasetFrameworkTest extends AbstractDatasetFrameworkTest {
                                  new HashSet<>(),
                                  typeService, instanceService);
     // Start dataset service, wait for it to be discoverable
-    service.startAndWait();
+    service.startAsync().awaitRunning();
     EndpointStrategy endpointStrategy = new RandomEndpointStrategy(
       () -> discoveryServiceClient.discover(Constants.Service.DATASET_MANAGER));
     Preconditions.checkNotNull(endpointStrategy.pick(5, TimeUnit.SECONDS),

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/DatasetServiceTestBase.java
@@ -187,7 +187,7 @@ public abstract class DatasetServiceTestBase {
     dsFramework = injector.getInstance(RemoteDatasetFramework.class);
     // Tx Manager to support working with datasets
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     StructuredTableAdmin structuredTableAdmin = injector.getInstance(StructuredTableAdmin.class);
     StoreDefinition.createAllTables(structuredTableAdmin);
 
@@ -206,7 +206,7 @@ public abstract class DatasetServiceTestBase {
 
     opExecutorService = new DatasetOpExecutorService(cConf, SConfiguration.create(),
                                                      discoveryService, commonNettyHttpServiceFactory, handlers);
-    opExecutorService.startAndWait();
+    opExecutorService.startAsync().awaitRunning();
 
     Map<String, DatasetModule> defaultModules =
       injector.getInstance(Key.get(new TypeLiteral<Map<String, DatasetModule>>() { },
@@ -252,7 +252,7 @@ public abstract class DatasetServiceTestBase {
                                  new HashSet<>(), typeService, instanceService);
 
     // Start dataset service, wait for it to be discoverable
-    service.startAndWait();
+    service.startAsync().awaitRunning();
     waitForService(Constants.Service.DATASET_EXECUTOR);
     waitForService(Constants.Service.DATASET_MANAGER);
     // this usually happens while creating a namespace, however not doing that in data fabric tests

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/datafabric/dataset/service/executor/DatasetOpExecutorServiceTest.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.data2.datafabric.dataset.service.executor;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
@@ -147,15 +148,15 @@ public class DatasetOpExecutorServiceTest {
         });
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     dsOpExecService = injector.getInstance(DatasetOpExecutorService.class);
-    dsOpExecService.startAndWait();
+    dsOpExecService.startAsync().awaitRunning();
 
     managerService = injector.getInstance(DatasetService.class);
-    managerService.startAndWait();
+    managerService.startAsync().awaitRunning();
 
     dsFramework = injector.getInstance(DatasetFramework.class);
 
@@ -173,10 +174,10 @@ public class DatasetOpExecutorServiceTest {
   public void tearDown() throws Exception {
     dsFramework = null;
 
-    dsOpExecService.stopAndWait();
+    dsOpExecService.stopAsync().awaitTerminated();
     dsOpExecService = null;
 
-    managerService.stopAndWait();
+    managerService.stopAsync().awaitTerminated();
     managerService = null;
 
     namespaceAdmin.delete(NamespaceId.DEFAULT);
@@ -269,7 +270,7 @@ public class DatasetOpExecutorServiceTest {
   }
 
   private DatasetAdminOpResponse getResponse(byte[] body) {
-    return Objects.firstNonNull(GSON.fromJson(Bytes.toString(body), DatasetAdminOpResponse.class),
+    return MoreObjects.firstNonNull(GSON.fromJson(Bytes.toString(body), DatasetAdminOpResponse.class),
         new DatasetAdminOpResponse(null, null));
   }
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/DatasetFrameworkTestUtil.java
@@ -102,7 +102,7 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
     );
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     framework = injector.getInstance(DatasetFramework.class);
   }
@@ -110,7 +110,7 @@ public final class DatasetFrameworkTestUtil extends ExternalResource {
   @Override
   protected void after() {
     if (txManager != null) {
-      txManager.stopAndWait();
+      txManager.stopAsync().awaitTerminated();
     }
     if (tmpFolder != null) {
       tmpFolder.delete();

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/cache/DynamicDatasetCacheTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.dataset2.cache;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -295,7 +294,7 @@ public abstract class DynamicDatasetCacheTest {
         Assert.assertSame(ds, ds2);
         ref.set(ds);
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
       try {
         // get the same dataset again. It should be the same object
@@ -303,7 +302,7 @@ public abstract class DynamicDatasetCacheTest {
         Assert.assertSame(ref.get(), ds);
         cache.discardDataset(ds);
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     });
 
@@ -315,7 +314,7 @@ public abstract class DynamicDatasetCacheTest {
         // validate that we now have a different instance because the old one was discarded
         Assert.assertNotSame(ref.get(), ds);
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
       // validate that only the new instance of the dataset remained active
       Assert.assertEquals(1,

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/AbstractCubeTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/AbstractCubeTest.java
@@ -34,6 +34,7 @@ import io.cdap.cdap.api.dataset.lib.cube.TimeValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -587,6 +588,8 @@ public abstract class AbstractCubeTest {
                           null);
     result = new ArrayList<>(cube.query(query));
     Assert.assertEquals(2, result.size());
+    // Sort by first timestamp to ensure deterministic ordering across Guava versions
+    result.sort(Comparator.comparingLong(ts -> ts.getTimeValues().get(0).getTimestamp()));
     // agg1 gets increment by 1 for 100 seconds, so sum will be 100/5=20, agg2 gets increment by 3 for 50 seconds, so
     // sum will be 3*50/5=30
     verifySumAggregation(result.get(0), "metric1", 5, 30, 10, 0, 0);

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/cube/CubeDatasetTest.java
@@ -102,7 +102,7 @@ public class CubeDatasetTest extends AbstractCubeTest {
 
     Configuration txConf = new Configuration();
     TransactionManager txManager = new TransactionManager(txConf);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     try {
       TransactionSystemClient txClient = new InMemoryTxSystemClient(txManager);
 
@@ -141,7 +141,7 @@ public class CubeDatasetTest extends AbstractCubeTest {
       txClient.commitOrThrow(tx);
       ((TransactionAware) cube2).postTxCommit();
     } finally {
-      txManager.stopAndWait();
+      txManager.stopAsync().awaitTerminated();
     }
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/TableConcurrentTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/TableConcurrentTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.data2.dataset2.lib.table;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.cdap.cdap.api.common.Bytes;
@@ -168,7 +167,7 @@ public abstract class TableConcurrentTest<T extends Table> extends TableTest<T> 
           continue;
         } catch (Throwable t) {
           LOG.warn("failed to increment, bailing out", t);
-          throw Throwables.propagate(t);
+          throw new RuntimeException(t);
         }
         executed[0]++;
       }
@@ -226,7 +225,7 @@ public abstract class TableConcurrentTest<T extends Table> extends TableTest<T> 
               continue;
             } catch (Throwable t) {
               LOG.warn("failed to append, bailing out", t);
-              throw Throwables.propagate(t);
+              throw new RuntimeException(t);
             }
 
             appended = true;

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/TableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/dataset2/lib/table/TableTest.java
@@ -127,7 +127,7 @@ public abstract class TableTest<T extends Table> {
   public void before() {
     Configuration txConf = new Configuration();
     TransactionManager txManager = new TransactionManager(txConf);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     txClient = new InMemoryTxSystemClient(txManager);
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/transaction/TransactionContextTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/data2/transaction/TransactionContextTest.java
@@ -58,13 +58,13 @@ public class TransactionContextTest {
   @BeforeClass
   public static void setup() {
     txManager = new TransactionManager(new Configuration());
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     txClient = new DummyTxClient(txManager);
   }
 
   @AfterClass
   public static void finish() {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   private TransactionContext newTransactionContext(TransactionAware... txAwares) {

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/kafka/KafkaTester.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/kafka/KafkaTester.java
@@ -128,19 +128,19 @@ public class KafkaTester extends ExternalResource {
   protected void before() throws Throwable {
     tmpFolder.create();
     zkServer = InMemoryZKServer.builder().setDataDir(tmpFolder.newFolder()).build();
-    zkServer.startAndWait();
+    zkServer.startAsync().awaitRunning();
     LOG.info("In memory ZK started on {}", zkServer.getConnectionStr());
 
     kafkaServer = new EmbeddedKafkaServer(generateKafkaConfig());
-    kafkaServer.startAndWait();
+    kafkaServer.startAsync().awaitRunning();
     initializeCconf();
     injector = createInjector();
     zkClient = injector.getInstance(ZKClientService.class);
-    zkClient.startAndWait();
+    zkClient.startAsync().awaitRunning();
     kafkaClient = injector.getInstance(KafkaClientService.class);
-    kafkaClient.startAndWait();
+    kafkaClient.startAsync().awaitRunning();
     brokerService = injector.getInstance(BrokerService.class);
-    brokerService.startAndWait();
+    brokerService.startAsync().awaitRunning();
 
     String brokerList = updateKafkaBrokerList(injector.getInstance(CConfiguration.class),
         brokerService);
@@ -151,11 +151,11 @@ public class KafkaTester extends ExternalResource {
 
   @Override
   protected void after() {
-    brokerService.stopAndWait();
-    kafkaClient.stopAndWait();
-    zkClient.stopAndWait();
-    kafkaServer.stopAndWait();
-    zkServer.stopAndWait();
+    brokerService.stopAsync().awaitTerminated();
+    kafkaClient.stopAsync().awaitTerminated();
+    zkClient.stopAsync().awaitTerminated();
+    kafkaServer.stopAsync().awaitTerminated();
+    zkServer.stopAsync().awaitTerminated();
   }
 
   private void initializeCconf() throws IOException {

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableAdminTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableAdminTest.java
@@ -42,7 +42,7 @@ public class NoSqlStructuredTableAdminTest extends StructuredTableAdminTest {
   public static void beforeClass() throws IOException {
     Configuration txConf = new Configuration();
     txManager = new TransactionManager(txConf);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     CConfiguration cConf = dsFrameworkUtil.getConfiguration();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
@@ -57,7 +57,7 @@ public class NoSqlStructuredTableAdminTest extends StructuredTableAdminTest {
   @AfterClass
   public static void afterClass() {
     if (txManager != null) {
-      txManager.stopAndWait();
+      txManager.stopAsync().awaitTerminated();
     }
   }
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableConcurrencyTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableConcurrencyTest.java
@@ -54,7 +54,7 @@ public class NoSqlStructuredTableConcurrencyTest extends StructuredTableConcurre
   public static void beforeClass() throws IOException {
     Configuration txConf = new Configuration();
     txManager = new TransactionManager(txConf);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     CConfiguration cConf = dsFrameworkUtil.getConfiguration();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
@@ -65,7 +65,7 @@ public class NoSqlStructuredTableConcurrencyTest extends StructuredTableConcurre
   @AfterClass
   public static void afterClass() {
     if (txManager != null) {
-      txManager.stopAndWait();
+      txManager.stopAsync().awaitTerminated();
     }
   }
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableRegistryTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableRegistryTest.java
@@ -48,13 +48,13 @@ public class NoSqlStructuredTableRegistryTest extends StructuredTableRegistryTes
   public static void beforeClass() {
     Configuration txConf = new Configuration();
     txManager = new TransactionManager(txConf);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
   }
 
   @AfterClass
   public static void afterClass() {
     if (txManager != null) {
-      txManager.stopAndWait();
+      txManager.stopAsync().awaitTerminated();
     }
   }
 }

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/data/nosql/NoSqlStructuredTableTest.java
@@ -76,7 +76,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
   public static void beforeClass() throws IOException {
     Configuration txConf = new Configuration();
     txManager = new TransactionManager(txConf);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     CConfiguration cConf = dsFrameworkUtil.getConfiguration();
     cConf.set(Constants.Dataset.DATA_STORAGE_IMPLEMENTATION, Constants.Dataset.DATA_STORAGE_NOSQL);
@@ -87,7 +87,7 @@ public class NoSqlStructuredTableTest extends StructuredTableTest {
   @AfterClass
   public static void afterClass() {
     if (txManager != null) {
-      txManager.stopAndWait();
+      txManager.stopAsync().awaitTerminated();
     }
   }
 

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/spi/metadata/dataset/DatasetMetadataStorageTest.java
@@ -25,7 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Closeables;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -107,7 +106,7 @@ public class DatasetMetadataStorageTest extends MetadataStorageTest {
 
     Injector injector = Guice.createInjector(modules);
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     storage = injector.getInstance(DatasetMetadataStorage.class);
     storage.createIndex();
 
@@ -116,9 +115,15 @@ public class DatasetMetadataStorageTest extends MetadataStorageTest {
 
   @AfterClass
   public static void teardown() throws IOException {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
     storage.dropIndex();
-    Closeables.closeQuietly(storage);
+    try {
+
+      storage.close();
+
+    } catch (Exception ignored) {
+
+    }
   }
 
   @Override

--- a/cdap-data-fabric/src/test/java/io/cdap/cdap/store/DefaultOwnerStoreTest.java
+++ b/cdap-data-fabric/src/test/java/io/cdap/cdap/store/DefaultOwnerStoreTest.java
@@ -86,7 +86,7 @@ public class DefaultOwnerStoreTest extends OwnerStoreTest {
       }
     );
 
-    injector.getInstance(TransactionManager.class).startAndWait();
+    injector.getInstance(TransactionManager.class).startAsync().awaitRunning();
 
     txRunner = injector.getInstance(TransactionRunner.class);
     StoreDefinition.OwnerStore.create(injector.getInstance(StructuredTableAdmin.class));

--- a/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
+++ b/cdap-elastic/src/main/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorage.java
@@ -22,7 +22,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.google.common.io.Closeables;
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -226,7 +225,13 @@ public class ElasticsearchMetadataStorage implements MetadataStorage {
 
   @Override
   public void close() {
-    Closeables.closeQuietly(client);
+    try {
+
+      client.close();
+
+    } catch (Exception ignored) {
+
+    }
   }
 
   @Override

--- a/cdap-elastic/src/test/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
+++ b/cdap-elastic/src/test/java/io/cdap/cdap/metadata/elastic/ElasticsearchMetadataStorageTest.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.metadata.elastic;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Closeables;
 import io.cdap.cdap.api.metadata.MetadataEntity;
 import io.cdap.cdap.api.metadata.MetadataScope;
 import io.cdap.cdap.common.conf.CConfiguration;
@@ -86,7 +85,13 @@ public class ElasticsearchMetadataStorageTest extends MetadataStorageTest {
       try {
         elasticStore.dropIndex();
       } finally {
-        Closeables.closeQuietly(elasticStore);
+        try {
+
+          elasticStore.close();
+
+        } catch (Exception ignored) {
+
+        }
       }
     }
   }

--- a/cdap-metadata-spi/src/test/java/io/cdap/cdap/spi/metadata/MetadataStorageTest.java
+++ b/cdap-metadata-spi/src/test/java/io/cdap/cdap/spi/metadata/MetadataStorageTest.java
@@ -25,7 +25,6 @@ import static io.cdap.cdap.spi.metadata.MetadataConstants.TTL_KEY;
 import static io.cdap.cdap.spi.metadata.MetadataKind.PROPERTY;
 import static io.cdap.cdap.spi.metadata.MetadataKind.TAG;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -508,7 +507,7 @@ public abstract class MetadataStorageTest {
       try {
         return mds.apply(mutation, MutationOptions.DEFAULT);
       } catch (IOException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     }).collect(Collectors.toList());
 
@@ -1654,7 +1653,7 @@ public abstract class MetadataStorageTest {
         try {
           completionService.take();
         } catch (InterruptedException e) {
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         }
       });
       // validate that all "r" tags were removed and all "c" and "t" tags were added
@@ -1715,7 +1714,7 @@ public abstract class MetadataStorageTest {
       try {
         completionService.take();
       } catch (InterruptedException e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     });
     // validate that all "r" tags were removed and all "c" and "t" tags were added
@@ -1725,7 +1724,7 @@ public abstract class MetadataStorageTest {
           Assert.assertEquals("For entity " + entities.get(e), expected.get(e),
                               mds.read(new Read(entities.get(e))).getTags(USER));
         } catch (Exception ex) {
-          throw Throwables.propagate(ex);
+          throw new RuntimeException(ex);
         }
       });
     // clean up
@@ -1768,7 +1767,7 @@ public abstract class MetadataStorageTest {
         Assert.assertTrue(ImmutableSet.of(Metadata.EMPTY, new Metadata(USER, tags("b")))
                             .contains(mds.read(new Read(entity))));
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     });
     // clean up
@@ -1816,7 +1815,7 @@ public abstract class MetadataStorageTest {
           try {
             completionService.take();
           } catch (InterruptedException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
           }
         });
         IntStream.range(0, numEntities).forEach(
@@ -1827,11 +1826,11 @@ public abstract class MetadataStorageTest {
               Assert.assertTrue(ImmutableSet.of(Metadata.EMPTY, new Metadata(USER, tags("b")))
                                   .contains(mds.read(new Read(entities.get(e)))));
             } catch (Exception ex) {
-              throw Throwables.propagate(ex);
+              throw new RuntimeException(ex);
             }
           });
       } catch (Exception e) {
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
     });
     mds.batch(entities.values().stream().map(Drop::new).collect(Collectors.toList()), MutationOptions.DEFAULT);

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/AbstractClientMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/AbstractClientMessagingService.java
@@ -16,10 +16,8 @@
 
 package io.cdap.cdap.messaging.client;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Closeables;
 import com.google.common.net.HttpHeaders;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -494,13 +492,19 @@ public abstract class AbstractClientMessagingService implements MessagingService
               .setPayload(Bytes.toBytes((ByteBuffer) messageRecord.get("payload")))
               .build();
         } catch (IOException e) {
-          throw Throwables.propagate(e);
+          throw new RuntimeException(e);
         }
       }
 
       @Override
       public void close() {
-        Closeables.closeQuietly(inputStream);
+        try {
+
+          inputStream.close();
+
+        } catch (Exception ignored) {
+
+        }
         urlConn.disconnect();
       }
     };

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientRollbackDetail.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/client/ClientRollbackDetail.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.messaging.client;
 
-import com.google.common.base.Throwables;
 import io.cdap.cdap.messaging.spi.RollbackDetail;
 import io.cdap.cdap.messaging.Schemas;
 import java.io.ByteArrayInputStream;
@@ -92,7 +91,7 @@ final class ClientRollbackDetail implements RollbackDetail {
       return decoded;
     } catch (IOException e) {
       // This shouldn't happen, otherwise the server and client is not compatible
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingService.java
@@ -127,14 +127,14 @@ public class LeaderElectionMessagingService extends AbstractIdleService implemen
             latch.countDown();
           }
         });
-    leaderElection.startAndWait();
+    leaderElection.startAsync().awaitRunning();
     latch.await();
   }
 
   @Override
   protected void shutDown() throws Exception {
     try {
-      leaderElection.stopAndWait();
+      leaderElection.stopAsync().awaitTerminated();
     } catch (Exception e) {
       // It can happen if it is currently disconnected from ZK. There is no harm in just continue the shutdown process.
       LOG.warn("Exception during shutting down leader election", e);
@@ -209,7 +209,7 @@ public class LeaderElectionMessagingService extends AbstractIdleService implemen
     }
 
     if (oldService != null) {
-      oldService.stopAndWait();
+      oldService.stopAsync().awaitTerminated();
     }
   }
 
@@ -217,11 +217,11 @@ public class LeaderElectionMessagingService extends AbstractIdleService implemen
     Runnable runnable = new Runnable() {
       @Override
       public void run() {
-        service.startAndWait();
+        service.startAsync().awaitRunning();
         // If failed to mark the service to become available, this means the follower() call happened before this,
         // so just go ahead and shutdown the service.
         if (!delegate.attemptMark(service, true)) {
-          service.stopAndWait();
+          service.stopAsync().awaitTerminated();
         }
       }
     };
@@ -260,15 +260,15 @@ public class LeaderElectionMessagingService extends AbstractIdleService implemen
 
     @Override
     protected void startUp() throws Exception {
-      messagingService.startAndWait();
-      httpService.startAndWait();
+      messagingService.startAsync().awaitRunning();
+      httpService.startAsync().awaitRunning();
     }
 
     @Override
     protected void shutDown() throws Exception {
       try {
-        httpService.stopAndWait();
-        messagingService.stopAndWait();
+        httpService.stopAsync().awaitTerminated();
+        messagingService.stopAsync().awaitTerminated();
       } finally {
         // Clear the table cache on shutting down.
         cacheProvider.clear();

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/server/MessagingHttpService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/server/MessagingHttpService.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.messaging.server;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
@@ -90,7 +91,7 @@ public class MessagingHttpService extends AbstractIdleService {
           private void logWithTrace(HttpRequest request, Throwable t) {
             LOG.trace("Error in handling request={} {} for user={}:", request.method().name(),
                 request.uri(),
-                Objects.firstNonNull(SecurityRequestContext.getUserId(), "<null>"), t);
+                MoreObjects.firstNonNull(SecurityRequestContext.getUserId(), "<null>"), t);
           }
         })
         .setHttpHandlers(handlers);

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/ConcurrentMessageWriter.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/ConcurrentMessageWriter.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.messaging.service;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import io.cdap.cdap.api.metrics.MetricsCollector;
 import io.cdap.cdap.api.metrics.NoopMetricsContext;
 import io.cdap.cdap.messaging.spi.RollbackDetail;
@@ -128,7 +127,11 @@ final class ConcurrentMessageWriter implements Closeable {
           pendingStoreRequest.getEndTimestamp(), pendingStoreRequest.getEndSequenceId());
     } else {
       metricsCollector.increment("persist.failure", 1L);
-      Throwables.propagateIfInstanceOf(pendingStoreRequest.getFailureCause(), IOException.class);
+      if (pendingStoreRequest.getFailureCause() instanceof IOException) {
+
+        throw (IOException) pendingStoreRequest.getFailureCause();
+
+      }
       throw new IOException("Unable to write message to " + storeRequest.getTopicId(),
           pendingStoreRequest.getFailureCause());
     }

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/service/CoreMessagingService.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.messaging.service;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Throwables;
 import com.google.common.cache.CacheBuilder;
@@ -25,7 +26,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
@@ -195,9 +195,9 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
       }
       return messageTableWriterCache.get(request.getTopicId()).persist(request, metadata);
     } catch (ExecutionException e) {
-      Throwable cause = Objects.firstNonNull(e.getCause(), e);
+      Throwable cause = MoreObjects.firstNonNull(e.getCause(), e);
       Throwables.propagateIfPossible(cause, TopicNotFoundException.class, IOException.class);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -207,9 +207,9 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
       TopicMetadata metadata = topicCache.get(request.getTopicId());
       payloadTableWriterCache.get(request.getTopicId()).persist(request, metadata);
     } catch (ExecutionException e) {
-      Throwable cause = Objects.firstNonNull(e.getCause(), e);
+      Throwable cause = MoreObjects.firstNonNull(e.getCause(), e);
       Throwables.propagateIfPossible(cause, TopicNotFoundException.class, IOException.class);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -227,7 +227,7 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
     // Throw if there is any failure in rollback.
     if (failure != null) {
       Throwables.propagateIfPossible(failure, TopicNotFoundException.class, IOException.class);
-      throw Throwables.propagate(failure);
+      throw new RuntimeException(failure);
     }
   }
 
@@ -267,7 +267,13 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
   protected void shutDown() throws Exception {
     messageTableWriterCache.invalidateAll();
     payloadTableWriterCache.invalidateAll();
-    Closeables.closeQuietly(tableFactory);
+    try {
+
+      tableFactory.close();
+
+    } catch (Exception ignored) {
+
+    }
     LOG.info("Core Messaging Service stopped");
   }
 
@@ -441,9 +447,9 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
     try {
       return topicCache.get(topicId);
     } catch (ExecutionException e) {
-      Throwable cause = Objects.firstNonNull(e.getCause(), e);
+      Throwable cause = MoreObjects.firstNonNull(e.getCause(), e);
       Throwables.propagateIfPossible(cause, TopicNotFoundException.class, IOException.class);
-      throw Throwables.propagate(e.getCause());
+      throw new RuntimeException(e.getCause());
     }
   }
 
@@ -659,7 +665,7 @@ public class CoreMessagingService extends AbstractIdleService implements Messagi
               // The start offset is only used for the first payloadIterator being constructed.
               startOffset = null;
             } catch (IOException e) {
-              throw Throwables.propagate(e);
+              throw new RuntimeException(e);
             }
           } else {
             // Otherwise, the message entry is the next message

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/DBScanIterator.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/DBScanIterator.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.messaging.store.leveldb;
 
-import com.google.common.base.Throwables;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.api.dataset.lib.AbstractCloseableIterator;
 import java.io.IOException;
@@ -64,7 +63,7 @@ final class DBScanIterator extends AbstractCloseableIterator<Map.Entry<byte[], b
     try {
       iterator.close();
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     } finally {
       endOfData();
       closed = true;

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/store/leveldb/LevelDBTableFactory.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.messaging.store.leveldb;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.Closeables;
 import com.google.gson.Gson;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
@@ -195,12 +194,22 @@ public final class LevelDBTableFactory implements TableFactory {
       this.metadataTable = null;
     }
     if (metadataTable != null) {
-      Closeables.closeQuietly(metadataTable.getLevelDB());
+      try {
+
+        metadataTable.getLevelDB().close();
+
+      } catch (Exception ignored) {
+
+      }
     }
     Collection<DB> dbs = levelDBs.values();
-    dbs.forEach(Closeables::closeQuietly);
+    dbs.forEach(db -> {
+      try { db.close(); } catch (Exception ignored) { }
+    });
     dbs.clear();
-    partitionedLevelDBs.values().forEach(Closeables::closeQuietly);
+    partitionedLevelDBs.values().forEach(db -> {
+      try { db.close(); } catch (Exception ignored) { }
+    });
     partitionedLevelDBs.clear();
   }
 
@@ -312,7 +321,13 @@ public final class LevelDBTableFactory implements TableFactory {
               break;
             }
             // We can safely remove and close the levelDB as no one should be accessing them anymore
-            Closeables.closeQuietly(levelDBs.remove(dataDBPath));
+            try {
+
+              levelDBs.remove(dataDBPath).close();
+
+            } catch (Exception ignored) {
+
+            }
             filesToDelete.add(dataDBPath);
 
             // Payload table
@@ -321,7 +336,13 @@ public final class LevelDBTableFactory implements TableFactory {
               break;
             }
             // We can safely remove and close the levelDB as no one should be accessing them anymore
-            Closeables.closeQuietly(levelDBs.remove(dataDBPath));
+            try {
+
+              levelDBs.remove(dataDBPath).close();
+
+            } catch (Exception ignored) {
+
+            }
             filesToDelete.add(dataDBPath);
           }
 

--- a/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingSubscriberService.java
+++ b/cdap-tms/src/main/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingSubscriberService.java
@@ -185,7 +185,7 @@ public abstract class AbstractMessagingSubscriberService<T> extends
     List<ImmutablePair<String, T>> currentTxMessages;
     String lastMessageId = null;
     MessageTrackingIterator iterator = new MessageTrackingIterator(messages.iterator());
-    Stopwatch stopwatch = new Stopwatch();
+    Stopwatch stopwatch = Stopwatch.createUnstarted();
     while (iterator.hasNext()) {
       currentTxMessages = new ArrayList<>();
 

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingServiceTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/distributed/LeaderElectionMessagingServiceTest.java
@@ -89,7 +89,7 @@ public class LeaderElectionMessagingServiceTest {
   @BeforeClass
   public static void init() throws IOException {
     zkServer = InMemoryZKServer.builder().setDataDir(TEMP_FOLDER.newFolder()).build();
-    zkServer.startAndWait();
+    zkServer.startAsync().awaitRunning();
 
     cConf = CConfiguration.create();
     cConf.set(Constants.Zookeeper.QUORUM, zkServer.getConnectionStr());
@@ -106,7 +106,7 @@ public class LeaderElectionMessagingServiceTest {
 
   @AfterClass
   public static void finish() {
-    zkServer.stopAndWait();
+    zkServer.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -118,11 +118,11 @@ public class LeaderElectionMessagingServiceTest {
 
     // Start a messaging service, which would becomes leader
     ZKClientService zkClient1 = injector1.getInstance(ZKClientService.class);
-    zkClient1.startAndWait();
+    zkClient1.startAsync().awaitRunning();
 
     final MessagingService firstService = injector1.getInstance(MessagingService.class);
     if (firstService instanceof Service) {
-      ((Service) firstService).startAndWait();
+      ((Service) firstService).startAsync().awaitRunning();
     }
 
     // Publish a message with the leader
@@ -130,11 +130,11 @@ public class LeaderElectionMessagingServiceTest {
 
     // Start another messaging service, this one would be follower
     ZKClientService zkClient2 = injector2.getInstance(ZKClientService.class);
-    zkClient2.startAndWait();
+    zkClient2.startAsync().awaitRunning();
 
     final MessagingService secondService = injector2.getInstance(MessagingService.class);
     if (secondService instanceof Service) {
-      ((Service) secondService).startAndWait();
+      ((Service) secondService).startAsync().awaitRunning();
     }
 
     // Try to call the follower, should get service unavailable.
@@ -175,7 +175,7 @@ public class LeaderElectionMessagingServiceTest {
 
     // Shutdown the current leader. The session timeout one should becomes leader again.
     if (secondService instanceof Service) {
-      ((Service) secondService).stopAndWait();
+      ((Service) secondService).stopAsync().awaitTerminated();
     }
 
     // Try to fetch message from the current leader again.
@@ -201,8 +201,8 @@ public class LeaderElectionMessagingServiceTest {
 
     Assert.assertEquals(Arrays.asList("Testing1", "Testing2"), messages);
 
-    zkClient1.stopAndWait();
-    zkClient2.stopAndWait();
+    zkClient1.stopAsync().awaitTerminated();
+    zkClient2.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -217,11 +217,11 @@ public class LeaderElectionMessagingServiceTest {
     try {
       Injector injector = createInjector(0);
       ZKClientService zkClient = injector.getInstance(ZKClientService.class);
-      zkClient.startAndWait();
+      zkClient.startAsync().awaitRunning();
 
       final MessagingService messagingService = injector.getInstance(MessagingService.class);
       if (messagingService instanceof Service) {
-        ((Service) messagingService).startAndWait();
+        ((Service) messagingService).startAsync().awaitRunning();
       }
 
       // Shouldn't be serving request yet.
@@ -246,9 +246,9 @@ public class LeaderElectionMessagingServiceTest {
       }, 10L, TimeUnit.SECONDS, 200, TimeUnit.MILLISECONDS);
 
       if (messagingService instanceof Service) {
-        ((Service) messagingService).stopAndWait();
+        ((Service) messagingService).stopAsync().awaitTerminated();
       }
-      zkClient.stopAndWait();
+      zkClient.stopAsync().awaitTerminated();
 
     } finally {
       cConf.setLong(Constants.MessagingSystem.HA_FENCING_DELAY_SECONDS, oldFencingDelay);

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/server/MessagingHttpServiceTest.java
@@ -130,13 +130,13 @@ public class MessagingHttpServiceTest {
     );
 
     httpService = injector.getInstance(MessagingHttpService.class);
-    httpService.startAndWait();
+    httpService.startAsync().awaitRunning();
     client = new DefaultClientMessagingService(injector.getInstance(RemoteClientFactory.class), compressPayload);
   }
 
   @After
   public void afterTest() {
-    httpService.stopAndWait();
+    httpService.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/service/ConcurrentMessageWriterTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/service/ConcurrentMessageWriterTest.java
@@ -232,14 +232,15 @@ public class ConcurrentMessageWriterTest {
       executor.submit(new Runnable() {
         @Override
         public void run() {
-          Stopwatch stopwatch = new Stopwatch();
+          Stopwatch stopwatch = Stopwatch.createUnstarted();
           try {
             barrier.await();
             stopwatch.start();
             for (int i = 0; i < requestPerThread; i++) {
               writer.persist(new TestStoreRequest(topicId, payload), metadata);
             }
-            LOG.info("Complete time for thread {} is {} ms", threadId, stopwatch.elapsedMillis());
+            LOG.info("Complete time for thread {} is {} ms", threadId,
+                stopwatch.elapsed(java.util.concurrent.TimeUnit.MILLISECONDS));
           } catch (Exception e) {
             LOG.error("Exception raised when persisting.", e);
           }
@@ -247,13 +248,13 @@ public class ConcurrentMessageWriterTest {
       });
     }
 
-    Stopwatch stopwatch = new Stopwatch();
+    Stopwatch stopwatch = Stopwatch.createUnstarted();
     barrier.await();
     stopwatch.start();
     executor.shutdown();
     Assert.assertTrue(executor.awaitTermination(1, TimeUnit.MINUTES));
 
-    LOG.info("Total time passed: {} ms", stopwatch.elapsedMillis());
+    LOG.info("Total time passed: {} ms", stopwatch.elapsed(java.util.concurrent.TimeUnit.MILLISECONDS));
 
     // Validate that the total number of messages written is correct
     List<RawMessage> messages = testWriter.getMessages().get(topicId);

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/MessageTableTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/MessageTableTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.messaging.store;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -282,7 +281,7 @@ public abstract class MessageTableTest {
                         try {
                           barrier.await();
                         } catch (Exception e) {
-                          throw Throwables.propagate(e);
+                          throw new RuntimeException(e);
                         }
                         return new TestMessageEntry(
                             topicId,

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/PayloadTableTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/store/PayloadTableTest.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.messaging.store;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -179,7 +178,7 @@ public abstract class PayloadTableTest {
                 try {
                   barrier.await();
                 } catch (Exception e) {
-                  throw Throwables.propagate(e);
+                  throw new RuntimeException(e);
                 }
                 return new TestPayloadEntry(topicId, GENERATION, threadId, 0, messageCount,
                     Bytes.toBytes("message " + threadId + " " + messageCount++));

--- a/cdap-tms/src/test/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingSubscriberServiceTest.java
+++ b/cdap-tms/src/test/java/io/cdap/cdap/messaging/subscriber/AbstractMessagingSubscriberServiceTest.java
@@ -120,14 +120,14 @@ public class AbstractMessagingSubscriberServiceTest {
     TestMessagingSubscriberService service = new TestMessagingSubscriberService(
       NamespaceId.DEFAULT.topic("test"), 100, 100, 1,
       RetryStrategies.noRetry(), metricsContext, 100);
-    service.startAndWait();
+    service.startAsync().awaitRunning();
     //First one
     Assert.assertEquals(Arrays.asList(ImmutablePair.of(null, 0), ImmutablePair.of(null, 1)),
                         processedMessages.poll(10, TimeUnit.SECONDS));
     //Retry
     Assert.assertEquals(Arrays.asList(ImmutablePair.of(null, 0), ImmutablePair.of(null, 1)),
                         processedMessages.poll(10, TimeUnit.SECONDS));
-    service.stopAndWait();
+    service.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -158,7 +158,7 @@ public class AbstractMessagingSubscriberServiceTest {
     TestMessagingSubscriberService service = new TestMessagingSubscriberService(
       NamespaceId.DEFAULT.topic("test"), 100, 100, 1,
       RetryStrategies.noRetry(), metricsContext, 3);
-    service.startAndWait();
+    service.startAsync().awaitRunning();
     Assert.assertEquals(Arrays.asList(ImmutablePair.of(null, 0), ImmutablePair.of(null, 1), ImmutablePair.of(null, 2)),
                         processedMessages.poll(10, TimeUnit.SECONDS));
     Assert.assertEquals(Arrays.asList(ImmutablePair.of(null, 3)),
@@ -167,7 +167,7 @@ public class AbstractMessagingSubscriberServiceTest {
                         processedMessages.poll(10, TimeUnit.SECONDS));
     Assert.assertEquals(Arrays.asList(ImmutablePair.of(null, 5), ImmutablePair.of(null, 6)),
                         processedMessages.poll(10, TimeUnit.SECONDS));
-    service.stopAndWait();
+    service.stopAsync().awaitTerminated();
   }
 
   /**
@@ -202,10 +202,10 @@ public class AbstractMessagingSubscriberServiceTest {
     TestMessagingSubscriberService service = new TestMessagingSubscriberService(
       NamespaceId.DEFAULT.topic("test"), 100, 2, 1,
       RetryStrategies.noRetry(), metricsContext, 2);
-    service.startAndWait();
+    service.startAsync().awaitRunning();
     Assert.assertEquals(Arrays.asList(ImmutablePair.of(null, 0), ImmutablePair.of(null, 1)),
                         processedMessages.poll(10, TimeUnit.SECONDS));
-    service.stopAndWait();
+    service.stopAsync().awaitTerminated();
   }
 
   class TestMessagingSubscriberService extends AbstractMessagingSubscriberService<Integer> {

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/AbstractLogPublisher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/AbstractLogPublisher.java
@@ -115,12 +115,12 @@ public abstract class AbstractLogPublisher<MESSAGE> extends AbstractRetryableSch
 
   @Override
   protected void logTaskFailure(Throwable t) {
-    OUTAGE_LOG.error("Publish log message failed for {}. Will be retried.", getServiceName(), t);
+    OUTAGE_LOG.error("Publish log message failed for {}. Will be retried.", serviceName(), t);
   }
 
   @Override
   protected long handleRetriesExhausted(Exception e) {
-    logError("Failed to publish log message by " + getServiceName(), e);
+    logError("Failed to publish log message by " + serviceName(), e);
     return 0;
   }
 
@@ -146,7 +146,7 @@ public abstract class AbstractLogPublisher<MESSAGE> extends AbstractRetryableSch
       try {
         publishMessages(buffer, false);
       } catch (Exception e) {
-        logError("Failed to publish log message by " + getServiceName(), e);
+        logError("Failed to publish log message by " + serviceName(), e);
       }
       // Ignore those that cannot be publish since we are already in shutdown sequence
       buffer.clear();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogMessage.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/LogMessage.java
@@ -20,7 +20,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.LoggerContextVO;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import io.cdap.cdap.common.logging.LoggingContext;
 import java.util.Map;
 import org.slf4j.Marker;
@@ -130,7 +130,7 @@ public class LogMessage implements ILoggingEvent {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("loggingEvent", loggingEvent)
         .add("loggingContext", loggingContext)
         .toString();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/kafka/KafkaLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/kafka/KafkaLogAppender.java
@@ -50,8 +50,8 @@ public final class KafkaLogAppender extends LogAppender {
   public void start() {
     KafkaLogPublisher publisher = new KafkaLogPublisher(cConf);
     Optional.ofNullable(kafkaLogPublisher.getAndSet(publisher))
-        .ifPresent(KafkaLogPublisher::stopAndWait);
-    publisher.startAndWait();
+        .ifPresent(s -> s.stopAsync().awaitTerminated());
+    publisher.startAsync().awaitRunning();
     addInfo("Successfully started KafkaLogAppender.");
     super.start();
   }
@@ -60,7 +60,7 @@ public final class KafkaLogAppender extends LogAppender {
   public void stop() {
     super.stop();
     Optional.ofNullable(kafkaLogPublisher.getAndSet(null))
-        .ifPresent(KafkaLogPublisher::stopAndWait);
+        .ifPresent(s -> s.stopAsync().awaitTerminated());
   }
 
   @Override

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/kafka/StringPartitioner.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/kafka/StringPartitioner.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.logging.appender.kafka;
 
+import java.nio.charset.StandardCharsets;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
 import com.google.inject.Inject;
@@ -47,6 +48,6 @@ public final class StringPartitioner implements Partitioner {
 
   @Override
   public int partition(Object key, int numPartitions) {
-    return Math.abs(Hashing.md5().hashString(key.toString()).asInt()) % this.numPartitions;
+    return Math.abs(Hashing.md5().hashString(key.toString(), StandardCharsets.UTF_8).asInt()) % this.numPartitions;
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/remote/RemoteLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/remote/RemoteLogAppender.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.logging.appender.remote;
 
 
+import java.nio.charset.StandardCharsets;
 import com.google.common.hash.Hashing;
 import com.google.common.net.HttpHeaders;
 import com.google.inject.Inject;
@@ -75,8 +76,8 @@ public class RemoteLogAppender extends LogAppender {
   public void start() {
     RemoteLogPublisher publisher = new RemoteLogPublisher(cConf, remoteClientFactory);
     Optional.ofNullable(this.publisher.getAndSet(publisher))
-        .ifPresent(RemoteLogPublisher::stopAndWait);
-    publisher.startAndWait();
+        .ifPresent(p -> p.stopAsync().awaitTerminated());
+    publisher.startAsync().awaitRunning();
     addInfo("Successfully started " + APPENDER_NAME);
     super.start();
   }
@@ -84,7 +85,7 @@ public class RemoteLogAppender extends LogAppender {
   @Override
   public void stop() {
     super.stop();
-    Optional.ofNullable(this.publisher.getAndSet(null)).ifPresent(RemoteLogPublisher::stopAndWait);
+    Optional.ofNullable(this.publisher.getAndSet(null)).ifPresent(p -> p.stopAsync().awaitTerminated());
     addInfo("Successfully stopped " + APPENDER_NAME);
   }
 
@@ -178,7 +179,7 @@ public class RemoteLogAppender extends LogAppender {
    * do not want kafka dependencies in this class, this method is added here.
    */
   private static int partition(String key, int numPartitions) {
-    return Math.abs(Hashing.md5().hashString(key).asInt()) % numPartitions;
+    return Math.abs(Hashing.md5().hashString(key, StandardCharsets.UTF_8).asInt()) % numPartitions;
   }
 
   private void encodeEvents(OutputStream os, DatumWriter<List<ByteBuffer>> datumWriter,

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogFileManager.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogFileManager.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.logging.appender.system;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.Closeables;
 import com.google.common.util.concurrent.Uninterruptibles;
 import io.cdap.cdap.common.io.Locations;
 import io.cdap.cdap.common.io.Syncable;
@@ -119,7 +118,13 @@ public final class LogFileManager implements Flushable, Syncable {
           location.getLocation());
     } catch (Throwable e) {
       // delete created file as there was exception while writing meta data
-      Closeables.closeQuietly(logFileOutputStream);
+      try {
+
+        logFileOutputStream.close();
+
+      } catch (Exception ignored) {
+
+      }
       Locations.deleteQuietly(location.getLocation());
       throw new IOException(e);
     }
@@ -173,7 +178,13 @@ public final class LogFileManager implements Flushable, Syncable {
     outputStreamMap.clear();
 
     for (LogFileOutputStream stream : streams) {
-      Closeables.closeQuietly(stream);
+      try {
+
+        stream.close();
+
+      } catch (Exception ignored) {
+
+      }
     }
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogFileOutputStream.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/system/LogFileOutputStream.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.logging.appender.system;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.io.Closeables;
 import io.cdap.cdap.common.io.ByteBuffers;
 import io.cdap.cdap.common.io.Syncable;
 import io.cdap.cdap.logging.serialize.LoggingEvent;
@@ -72,8 +71,20 @@ class LogFileOutputStream implements Closeable, Flushable, Syncable {
       this.createTime = createTime;
       this.fileSize = 0;
     } catch (IOException e) {
-      Closeables.closeQuietly(outputStream);
-      Closeables.closeQuietly(dataFileWriter);
+      try {
+
+        outputStream.close();
+
+      } catch (Exception ignored) {
+
+      }
+      try {
+
+        dataFileWriter.close();
+
+      } catch (Exception ignored) {
+
+      }
       throw e;
     }
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/appender/tms/TMSLogAppender.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.logging.appender.tms;
 
+import java.nio.charset.StandardCharsets;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
 import com.google.inject.Inject;
@@ -66,8 +67,8 @@ public class TMSLogAppender extends LogAppender {
   public void start() {
     TMSLogPublisher publisher = new TMSLogPublisher(cConf, messagingService);
     Optional.ofNullable(tmsLogPublisher.getAndSet(publisher))
-        .ifPresent(TMSLogPublisher::stopAndWait);
-    publisher.startAndWait();
+        .ifPresent(s -> s.stopAsync().awaitTerminated());
+    publisher.startAsync().awaitRunning();
     addInfo("Successfully started " + APPENDER_NAME);
     super.start();
   }
@@ -75,7 +76,7 @@ public class TMSLogAppender extends LogAppender {
   @Override
   public void stop() {
     super.stop();
-    Optional.ofNullable(tmsLogPublisher.getAndSet(null)).ifPresent(TMSLogPublisher::stopAndWait);
+    Optional.ofNullable(tmsLogPublisher.getAndSet(null)).ifPresent(s -> s.stopAsync().awaitTerminated());
     addInfo("Successfully stopped " + APPENDER_NAME);
   }
 
@@ -95,7 +96,7 @@ public class TMSLogAppender extends LogAppender {
   // in Standalone
   @VisibleForTesting
   static int partition(Object key, int numPartitions) {
-    return Math.abs(Hashing.md5().hashString(key.toString()).asInt()) % numPartitions;
+    return Math.abs(Hashing.md5().hashString(key.toString(), StandardCharsets.UTF_8).asInt()) % numPartitions;
   }
 
   /**

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/AndFilter.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/AndFilter.java
@@ -17,7 +17,7 @@
 package io.cdap.cdap.logging.filter;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
@@ -44,7 +44,7 @@ public class AndFilter implements Filter {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("expressions", expressions)
         .toString();
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/FilterParser.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/FilterParser.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.logging.filter;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.StreamTokenizer;
@@ -58,7 +57,7 @@ public final class FilterParser {
         }
       }
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     // Not an empty expression
@@ -116,7 +115,7 @@ public final class FilterParser {
         }
       }
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     throw new IllegalStateException("Expected operand but got end of expression");
   }
@@ -136,7 +135,7 @@ public final class FilterParser {
         }
       }
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     throw new IllegalStateException("Expected operator = but got end of expression");
   }
@@ -156,7 +155,7 @@ public final class FilterParser {
         }
       }
     } catch (IOException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
 
     // No operator present

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/MdcExpression.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/MdcExpression.java
@@ -17,7 +17,7 @@
 package io.cdap.cdap.logging.filter;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Represents an expression that can match a key,value in MDC.
@@ -48,7 +48,7 @@ public class MdcExpression implements Filter {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("key", key)
         .add("value", value)
         .toString();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/OrFilter.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/filter/OrFilter.java
@@ -17,7 +17,7 @@
 package io.cdap.cdap.logging.filter;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 
@@ -44,7 +44,7 @@ public class OrFilter implements Filter {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("expressions", expressions)
         .toString();
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/distributed/DistributedLogFramework.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/distributed/DistributedLogFramework.java
@@ -17,10 +17,7 @@
 package io.cdap.cdap.logging.framework.distributed;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.AbstractIdleService;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -42,7 +39,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import org.apache.twill.discovery.DiscoveryService;
 import org.apache.twill.discovery.DiscoveryServiceClient;
 import org.apache.twill.kafka.client.BrokerService;
@@ -112,46 +108,41 @@ public class DistributedLogFramework extends ResourceBalancerService {
       @Override
       protected void startUp() throws Exception {
         // Starts all pipeline
-        validateAllFutures(Iterables.transform(pipelines, Service::start));
+        List<Exception> failures = new ArrayList<>();
+        for (Service pipeline : pipelines) {
+          try {
+            pipeline.startAsync().awaitRunning();
+          } catch (Exception e) {
+            failures.add(e);
+          }
+        }
+        throwIfNeeded(failures);
       }
 
       @Override
       protected void shutDown() throws Exception {
         // Stops all pipeline
-        validateAllFutures(Iterables.transform(pipelines, Service::stop));
+        List<Exception> failures = new ArrayList<>();
+        for (Service pipeline : pipelines) {
+          try {
+            pipeline.stopAsync().awaitTerminated();
+          } catch (Exception e) {
+            failures.add(e);
+          }
+        }
+        throwIfNeeded(failures);
       }
-    };
-  }
 
-  /**
-   * Blocks and validates all the given futures completed successfully.
-   */
-  private void validateAllFutures(Iterable<? extends ListenableFuture<?>> futures)
-      throws Exception {
-    // The get call shouldn't throw exception. It just block until all futures completed.
-    Futures.successfulAsList(futures).get();
-
-    // Iterates all futures to make sure all of them completed successfully
-    Throwable exception = null;
-    for (ListenableFuture<?> future : futures) {
-      try {
-        future.get();
-      } catch (ExecutionException e) {
-        if (exception == null) {
-          exception = e.getCause();
-        } else {
-          exception.addSuppressed(e.getCause());
+      private void throwIfNeeded(List<Exception> failures) throws Exception {
+        if (!failures.isEmpty()) {
+          Exception first = failures.get(0);
+          for (int i = 1; i < failures.size(); i++) {
+            first.addSuppressed(failures.get(i));
+          }
+          throw first;
         }
       }
-    }
-
-    // Throw exception if any of the future failed.
-    if (exception != null) {
-      if (exception instanceof Exception) {
-        throw (Exception) exception;
-      }
-      throw new RuntimeException(exception);
-    }
+    };
   }
 
   /**

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/local/LocalLogAppender.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/framework/local/LocalLogAppender.java
@@ -96,12 +96,12 @@ public class LocalLogAppender extends LogAppender {
               spec.getContext().getMetricsContext(), spec.getContext().getInstanceId());
       LocalLogProcessorPipeline pipeline = new LocalLogProcessorPipeline(context,
           syncIntervalMillis);
-      pipeline.startAndWait();
+      pipeline.startAsync().awaitRunning();
       pipelineThreads.add(pipeline.getAppenderThread());
       pipelines.add(pipeline);
     }
 
-    this.pipelines.getAndSet(pipelines).forEach(LocalLogProcessorPipeline::stopAndWait);
+    this.pipelines.getAndSet(pipelines).forEach(s -> s.stopAsync().awaitTerminated());
     this.pipelineThreads.set(pipelineThreads);
 
     super.start();
@@ -113,7 +113,7 @@ public class LocalLogAppender extends LogAppender {
     super.stop();
     for (LocalLogProcessorPipeline pipeline : pipelines.getAndSet(Collections.emptyList())) {
       try {
-        pipeline.stopAndWait();
+        pipeline.stopAsync().awaitTerminated();
       } catch (Throwable t) {
         addError("Exception raised when stopping log processing pipeline " + pipeline.getName(), t);
       }
@@ -174,7 +174,7 @@ public class LocalLogAppender extends LogAppender {
     @Override
     protected Executor executor() {
       // Copy from parent, but using a different thread name
-      // Can't override the getServiceName() method as it is missing from some Guava version.
+      // Using custom thread name instead of serviceName().
       return command -> new Thread(command, "LocalLogProcessor-" + getName()).start();
     }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/AbstractChunkedCallback.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/AbstractChunkedCallback.java
@@ -16,8 +16,6 @@
 
 package io.cdap.cdap.logging.gateway.handlers;
 
-import com.google.common.collect.Multimap;
-import com.google.common.io.Closeables;
 import io.cdap.cdap.logging.read.Callback;
 import io.cdap.cdap.logging.read.LogEvent;
 import io.cdap.http.ChunkResponder;
@@ -112,7 +110,13 @@ public abstract class AbstractChunkedCallback implements Callback {
       // Just log the error as debug.
       LOG.debug("Failed to send chunk", e);
     } finally {
-      Closeables.closeQuietly(chunkResponder);
+      try {
+
+        chunkResponder.close();
+
+      } catch (Exception ignored) {
+
+      }
     }
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/AbstractJSONCallback.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/AbstractJSONCallback.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.logging.gateway.handlers;
 
-import com.google.common.base.Throwables;
 import com.google.gson.Gson;
 import io.cdap.cdap.logging.read.LogEvent;
 import io.cdap.http.HttpResponder;
@@ -69,7 +68,7 @@ public abstract class AbstractJSONCallback extends AbstractChunkedCallback {
       encodeSend(CharBuffer.wrap(GSON.toJson(encodeSend(logEvent))), false);
     } catch (IOException e) {
       // Just propagate the exception, the caller of this Callback should be handling it.
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteLogsFetcher.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/gateway/handlers/RemoteLogsFetcher.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.logging.gateway.handlers;
 
-import com.google.common.io.Closeables;
 import com.google.inject.Inject;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.conf.Constants.Gateway;
@@ -114,7 +113,13 @@ public class RemoteLogsFetcher implements LogsFetcher {
 
         @Override
         public void onFinished() {
-          Closeables.closeQuietly(channel);
+          try {
+
+            channel.close();
+
+          } catch (Exception ignored) {
+
+          }
         }
       }).build();
       remoteClient.executeStreamingRequest(request);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/ConcurrentLogBufferWriter.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/ConcurrentLogBufferWriter.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.logging.logbuffer;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import io.cdap.cdap.common.conf.CConfiguration;
 import io.cdap.cdap.common.conf.Constants;
@@ -92,8 +91,11 @@ public class ConcurrentLogBufferWriter implements Closeable {
     }
 
     if (!pendingLogBufferRequest.isSuccess()) {
-      Throwables.propagateIfInstanceOf(pendingLogBufferRequest.getFailureCause(),
-          IOException.class);
+      if (pendingLogBufferRequest.getFailureCause() instanceof IOException) {
+
+        throw (IOException) pendingLogBufferRequest.getFailureCause();
+
+      }
       throw new IOException("Unable to write log event to log buffer",
           pendingLogBufferRequest.getFailureCause());
     }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/LogBufferService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/LogBufferService.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.logging.logbuffer;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -102,7 +101,12 @@ public class LogBufferService extends AbstractIdleService {
     // load log pipelines
     List<LogBufferProcessorPipeline> bufferPipelines = loadLogPipelines();
     // start all the log pipelines
-    validateAllFutures(Iterables.transform(pipelines, Service::start));
+    for (Service pipeline : pipelines) {
+      pipeline.startAsync();
+    }
+    for (Service pipeline : pipelines) {
+      pipeline.awaitRunning();
+    }
 
     // recovery service and http handler will send log events to log pipelines. In order to avoid deleting file while
     // reading them in recovery service, we will pass in an atomic boolean will be set to true by recovery service
@@ -111,7 +115,7 @@ public class LogBufferService extends AbstractIdleService {
     // start log recovery service to recover all the pending logs.
     recoveryService = new LogBufferRecoveryService(cConf, bufferPipelines, checkpointManagers,
         startCleanup);
-    recoveryService.startAndWait();
+    recoveryService.startAsync().awaitRunning();
 
     // create concurrent writer
     ConcurrentLogBufferWriter concurrentWriter = new ConcurrentLogBufferWriter(cConf,
@@ -231,9 +235,14 @@ public class LogBufferService extends AbstractIdleService {
       httpService.stop();
     }
     if (recoveryService != null) {
-      recoveryService.stopAndWait();
+      recoveryService.stopAsync().awaitTerminated();
     }
     // Stops all pipeline
-    validateAllFutures(Iterables.transform(pipelines, Service::stop));
+    for (Service pipeline : pipelines) {
+      pipeline.stopAsync();
+    }
+    for (Service pipeline : pipelines) {
+      pipeline.awaitTerminated();
+    }
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/LogBufferWriter.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/LogBufferWriter.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.logging.logbuffer;
 
-import com.google.common.io.Closeables;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.logging.serialize.LoggingEventSerializer;
 import java.io.BufferedOutputStream;
@@ -154,7 +153,16 @@ public class LogBufferWriter implements Flushable, Closeable {
       LOG.warn("Error while flushing log buffer output stream.", e);
     }
 
-    Closeables.closeQuietly(currOutputStream);
+    try {
+
+
+      currOutputStream.close();
+
+
+    } catch (Exception ignored) {
+
+
+    }
     executorService.shutdown();
   }
 
@@ -184,7 +192,13 @@ public class LogBufferWriter implements Flushable, Closeable {
   private Location rotateFile(OutputStream currOutputStream) throws IOException {
     currOutputStream.flush();
     // close current location output stream
-    Closeables.closeQuietly(currOutputStream);
+    try {
+
+      currOutputStream.close();
+
+    } catch (Exception ignored) {
+
+    }
 
     writtenBytes = 0;
     currOffset = 0;

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/recover/LogBufferReader.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/recover/LogBufferReader.java
@@ -16,7 +16,6 @@
 
 package io.cdap.cdap.logging.logbuffer.recover;
 
-import com.google.common.io.Closeables;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.logging.logbuffer.LogBufferEvent;
 import io.cdap.cdap.logging.logbuffer.LogBufferFileOffset;
@@ -169,7 +168,13 @@ public class LogBufferReader implements Closeable {
      */
     public void close() {
       // close input stream wrapped by this reader
-      Closeables.closeQuietly(inputStream);
+      try {
+
+        inputStream.close();
+
+      } catch (Exception ignored) {
+
+      }
     }
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/recover/LogBufferRecoveryService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/logbuffer/recover/LogBufferRecoveryService.java
@@ -127,7 +127,7 @@ public class LogBufferRecoveryService extends AbstractExecutionThreadService {
   }
 
   @Override
-  protected String getServiceName() {
+  protected String serviceName() {
     return SERVICE_NAME;
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/meta/Checkpoint.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/meta/Checkpoint.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.logging.meta;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Represents a checkpoint that can be saved when reading logs.
@@ -52,7 +52,7 @@ public class Checkpoint<Offset> {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("Offset", offset)
         .add("maxEventTime", maxEventTime)
         .toString();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/kafka/KafkaLogProcessorPipeline.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/kafka/KafkaLogProcessorPipeline.java
@@ -46,16 +46,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-import kafka.api.OffsetRequest$;
 import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.MessageAndOffset;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.errors.LeaderNotAvailableException;
-import org.apache.kafka.common.errors.NotLeaderForPartitionException;
 import org.apache.kafka.common.errors.OffsetOutOfRangeException;
-import org.apache.kafka.common.errors.UnknownServerException;
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.twill.common.Threads;
 import org.apache.twill.kafka.client.BrokerInfo;
 import org.apache.twill.kafka.client.BrokerService;
@@ -223,7 +219,7 @@ public final class KafkaLogProcessorPipeline extends AbstractExecutionThreadServ
   }
 
   @Override
-  protected String getServiceName() {
+  protected String serviceName() {
     return "LogPipeline-" + name;
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipeline.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipeline.java
@@ -139,7 +139,7 @@ public class LogBufferProcessorPipeline extends AbstractExecutionThreadService {
   }
 
   @Override
-  protected String getServiceName() {
+  protected String serviceName() {
     return "LogPipeline-" + name;
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/plugins/LocationManager.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/plugins/LocationManager.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.Closeables;
 import io.cdap.cdap.common.conf.Constants;
 import io.cdap.cdap.common.io.Syncable;
 import java.io.Closeable;
@@ -175,7 +174,13 @@ public class LocationManager implements Flushable, Closeable, Syncable {
 
     for (LocationOutputStream locationOutputStream : locations) {
       // we do not want to throw any exception rather close all the open output streams. so close quietly
-      Closeables.closeQuietly(locationOutputStream);
+      try {
+
+        locationOutputStream.close();
+
+      } catch (Exception ignored) {
+
+      }
     }
 
     activeLocations.clear();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/FileLogReader.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/FileLogReader.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.logging.read;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -87,7 +86,7 @@ public class FileLogReader implements LogReader {
       }
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -133,7 +132,7 @@ public class FileLogReader implements LogReader {
       }
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 
@@ -204,7 +203,7 @@ public class FileLogReader implements LogReader {
       return concat(closeableIterator);
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/KafkaLogReader.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/KafkaLogReader.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.logging.read;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.lib.CloseableIterator;
@@ -112,7 +111,7 @@ public class KafkaLogReader implements LogReader {
       fetchLogEvents(kafkaConsumer, kafkaCallback, startOffset, latestOffset, maxEvents, readRange);
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     } finally {
       try {
         kafkaConsumer.close();
@@ -190,7 +189,7 @@ public class KafkaLogReader implements LogReader {
       }
     } catch (Throwable e) {
       LOG.error("Got exception: ", e);
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     } finally {
       try {
         kafkaConsumer.close();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/LogOffset.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/LogOffset.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.logging.read;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Represents log offset containing Kafka offset and time of logging event.
@@ -45,7 +45,7 @@ public class LogOffset {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("kafkaOffset", kafkaOffset)
         .add("time", time)
         .toString();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/ReadRange.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/read/ReadRange.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.logging.read;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Boundary of a log read request.
@@ -64,7 +64,7 @@ public class ReadRange {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("fromMillis", fromMillis)
         .add("toMillis", toMillis)
         .add("kafkaOffset", kafkaOffset)

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/serialize/LoggingEventSerializer.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/serialize/LoggingEventSerializer.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.logging.serialize;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.base.Throwables;
 import io.cdap.cdap.api.common.Bytes;
 import io.cdap.cdap.logging.LoggingUtil;
 import java.io.ByteArrayOutputStream;
@@ -67,7 +66,7 @@ public final class LoggingEventSerializer {
       writer.write(toGenericRecord(event), encoder);
     } catch (IOException e) {
       // This shouldn't happen since we are writing to byte array output stream.
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     return out.toByteArray();
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/service/LogSaverStatusService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/service/LogSaverStatusService.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.logging.service;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -90,7 +90,7 @@ public class LogSaverStatusService extends AbstractIdleService {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("bindAddress", httpService.getBindAddress())
         .toString();
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/logging/write/LogLocation.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/logging/write/LogLocation.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.logging.write;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -418,7 +417,7 @@ public class LogLocation {
         throw e;
       } catch (Exception e) {
         // should not happen
-        throw Throwables.propagate(e);
+        throw new RuntimeException(e);
       }
 
       this.len = location.length();

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/collect/LocalMetricsCollectionService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/collect/LocalMetricsCollectionService.java
@@ -88,11 +88,11 @@ public final class LocalMetricsCollectionService extends AggregatedMetricsCollec
           IntStream.range(0, cConf.getInt(Constants.Metrics.MESSAGING_TOPIC_NUM)).boxed()
               .collect(Collectors.toSet()),
           getContext(METRICS_PROCESSOR_CONTEXT), 0);
-      messagingMetricsProcessor.startAndWait();
+      messagingMetricsProcessor.startAsync().awaitRunning();
     }
 
     // The local metrics store do not have ttl, so start the clean up service
-    metricsCleanUpService.startAndWait();
+    metricsCleanUpService.startAsync().awaitRunning();
   }
 
   @Override
@@ -101,7 +101,7 @@ public final class LocalMetricsCollectionService extends AggregatedMetricsCollec
     Exception failure = null;
     try {
       if (messagingMetricsProcessor != null) {
-        messagingMetricsProcessor.stopAndWait();
+        messagingMetricsProcessor.stopAsync().awaitTerminated();
       }
     } catch (Exception e) {
       failure = e;
@@ -120,7 +120,7 @@ public final class LocalMetricsCollectionService extends AggregatedMetricsCollec
 
     // Shutdown the clean up service
     try {
-      metricsCleanUpService.stopAndWait();
+      metricsCleanUpService.stopAsync().awaitTerminated();
     } catch (Exception e) {
       if (failure != null) {
         failure.addSuppressed(e);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/guice/DistributedMetricsClientModule.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/guice/DistributedMetricsClientModule.java
@@ -15,7 +15,6 @@
  */
 package io.cdap.cdap.metrics.guice;
 
-import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.PrivateModule;
 import com.google.inject.Provides;
@@ -24,11 +23,9 @@ import io.cdap.cdap.api.data.schema.UnsupportedTypeException;
 import io.cdap.cdap.api.metrics.MetricValues;
 import io.cdap.cdap.api.metrics.MetricsCollectionService;
 import io.cdap.cdap.api.metrics.MetricsSystemClient;
-import io.cdap.cdap.common.guice.IOModule;
 import io.cdap.cdap.common.io.DatumWriter;
 import io.cdap.cdap.internal.io.DatumWriterFactory;
 import io.cdap.cdap.internal.io.SchemaGenerator;
-import io.cdap.cdap.messaging.spi.MessagingService;
 import io.cdap.cdap.metrics.collect.MessagingMetricsCollectionService;
 import io.cdap.cdap.metrics.process.RemoteMetricsSystemClient;
 
@@ -58,7 +55,7 @@ final class DistributedMetricsClientModule extends PrivateModule {
       return datumWriterFactory.create(METRIC_RECORD_TYPE,
           schemaGenerator.generate(METRIC_RECORD_TYPE.getType()));
     } catch (UnsupportedTypeException e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerService.java
@@ -144,7 +144,7 @@ public class MessagingMetricsProcessorManagerService extends AbstractIdleService
     }
 
     for (MessagingMetricsProcessorService processorService : metricsProcessorServices) {
-      processorService.startAndWait();
+      processorService.startAsync().awaitRunning();
     }
   }
 
@@ -192,7 +192,7 @@ public class MessagingMetricsProcessorManagerService extends AbstractIdleService
     Exception exceptions = new Exception();
     for (MessagingMetricsProcessorService processorService : metricsProcessorServices) {
       try {
-        processorService.stopAndWait();
+        processorService.stopAsync().awaitTerminated();
         for (MetricsWriter metricsWriter : metricsWriters) {
           metricsWriter.close();
         }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorService.java
@@ -17,7 +17,6 @@
 package io.cdap.cdap.metrics.process;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.AbstractExecutionThreadService;
 import com.google.inject.Inject;
@@ -150,7 +149,7 @@ public class MessagingMetricsProcessorService extends AbstractExecutionThreadSer
       this.metricReader = readerFactory.create(TypeToken.of(MetricValues.class), metricSchema);
     } catch (UnsupportedTypeException e) {
       // This should never happen
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
     this.metricsWriter = metricsWriter;
     this.maxDelayMillis = cConf.getLong(Constants.Metrics.PROCESSOR_MAX_DELAY_MS);

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MetricsProcessorStatusService.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/process/MetricsProcessorStatusService.java
@@ -16,7 +16,7 @@
 
 package io.cdap.cdap.metrics.process;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.AbstractIdleService;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -99,7 +99,7 @@ public class MetricsProcessorStatusService extends AbstractIdleService {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("bindAddress", httpService.getBindAddress())
         .toString();
   }

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/TimeseriesId.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/query/TimeseriesId.java
@@ -16,6 +16,7 @@
 
 package io.cdap.cdap.metrics.query;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 /**
@@ -54,7 +55,7 @@ public final class TimeseriesId {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("context", context)
         .add("metric", metric)
         .add("tag", tag)

--- a/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricDatasetFactory.java
+++ b/cdap-watchdog/src/main/java/io/cdap/cdap/metrics/store/DefaultMetricDatasetFactory.java
@@ -18,7 +18,6 @@ package io.cdap.cdap.metrics.store;
 
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.cdap.cdap.api.dataset.DatasetAdmin;
 import io.cdap.cdap.api.dataset.DatasetContext;
@@ -102,7 +101,7 @@ public class DefaultMetricDatasetFactory implements MetricDatasetFactory {
       // metrics tables are in the system namespace
       return getOrCreateTable(NamespaceId.SYSTEM.dataset(tableName), props);
     } catch (Exception e) {
-      throw Throwables.propagate(e);
+      throw new RuntimeException(e);
     }
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/ErrorLogsClassifierTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/ErrorLogsClassifierTest.java
@@ -70,13 +70,13 @@ public class ErrorLogsClassifierTest {
     List<MetricValues> metricValuesList = new ArrayList<>();
     MetricsCollectionService mockMetricsCollectionService =
         getMockCollectionService(metricValuesList);
-    mockMetricsCollectionService.startAndWait();
+    mockMetricsCollectionService.startAsync().awaitRunning();
     CConfiguration cConf = Mockito.mock(CConfiguration.class);
     ErrorLogsClassifier classifier = new ErrorLogsClassifier(cConf, mockMetricsCollectionService);
     classifier.classify(closeableIterator, responder, "namespace", "program", "app", "run");
     List<ErrorClassificationResponse> responses =
         GSON.fromJson(responder.getResponseContentAsString(), LIST_TYPE);
-    mockMetricsCollectionService.stopAndWait();
+    mockMetricsCollectionService.stopAsync().awaitTerminated();
     Assert.assertEquals(1, responses.size());
     Assert.assertEquals("stageName", responses.get(0).getStageName());
     Assert.assertEquals("errorCategory-'stageName'", responses.get(0).getErrorCategory());
@@ -98,7 +98,7 @@ public class ErrorLogsClassifierTest {
     List<MetricValues> metricValuesList = new ArrayList<>();
     MetricsCollectionService mockMetricsCollectionService =
         getMockCollectionService(metricValuesList);
-    mockMetricsCollectionService.startAndWait();
+    mockMetricsCollectionService.startAsync().awaitRunning();
     CConfiguration cConf = Mockito.mock(CConfiguration.class);
     ErrorLogsClassifier classifier = new ErrorLogsClassifier(cConf, mockMetricsCollectionService);
     LogEvent logEvent3 = new LogEvent(getEvent3(IllegalArgumentException.class.getName()),
@@ -112,10 +112,10 @@ public class ErrorLogsClassifierTest {
     Mockito.when(spy.getRuleList()).thenReturn(getRulesList());
     Mockito.doCallRealMethod().when(spy).classify(Mockito.any(), Mockito.any(), Mockito.any(),
         Mockito.any(), Mockito.any(), Mockito.any());
-    mockMetricsCollectionService.startAndWait();
+    mockMetricsCollectionService.startAsync().awaitRunning();
     CloseableIterator<LogEvent> closeableIterator = getCloseableIterator(events.iterator());
     spy.classify(closeableIterator, responder, "namespace", "program", "app", "run2");
-    mockMetricsCollectionService.stopAndWait();
+    mockMetricsCollectionService.stopAsync().awaitTerminated();
     List<ErrorClassificationResponse> responses =
         GSON.fromJson(responder.getResponseContentAsString(), LIST_TYPE);
     Assert.assertEquals(1, responses.size());

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ErrorClassificationLoggingTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ErrorClassificationLoggingTest.java
@@ -147,6 +147,6 @@ public class ErrorClassificationLoggingTest {
 
   @AfterClass
   public static void cleanUp() {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 }

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ErrorTagProviderLoggingTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/ErrorTagProviderLoggingTest.java
@@ -104,7 +104,7 @@ public class ErrorTagProviderLoggingTest {
 
   @AfterClass
   public static void cleanUp() throws Exception {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
 }

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LocalLogAppenderResilientTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LocalLogAppenderResilientTest.java
@@ -134,12 +134,12 @@ public class LocalLogAppenderResilientTest {
         });
 
     TransactionManager txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
     DatasetOpExecutorService opExecutorService = injector
         .getInstance(DatasetOpExecutorService.class);
-    opExecutorService.startAndWait();
+    opExecutorService.startAsync().awaitRunning();
 
     // Start the logging before starting the service.
     LoggingContextAccessor
@@ -187,7 +187,7 @@ public class LocalLogAppenderResilientTest {
 
     // Start dataset service, wait for it to be discoverable
     DatasetService dsService = injector.getInstance(DatasetService.class);
-    dsService.startAndWait();
+    dsService.startAsync().awaitRunning();
 
     final CountDownLatch startLatch = new CountDownLatch(1);
     DiscoveryServiceClient discoveryClient = injector.getInstance(DiscoveryServiceClient.class);

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LoggingTester.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/LoggingTester.java
@@ -113,7 +113,7 @@ public class LoggingTester {
   public static TransactionManager createTransactionManager(Injector injector) throws IOException {
 
     TransactionManager txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     return txManager;
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/TestDistributedLogReader.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/TestDistributedLogReader.java
@@ -97,7 +97,7 @@ public class TestDistributedLogReader extends KafkaTestBase {
         stringPartitioner.partition(LOGGING_CONTEXT_KAFKA.getLogPartition(), -1));
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
 
@@ -152,7 +152,7 @@ public class TestDistributedLogReader extends KafkaTestBase {
   @AfterClass
   public static void cleanUp() throws Exception {
     InMemoryTableService.reset();
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/file/TestFileLogging.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/file/TestFileLogging.java
@@ -66,7 +66,7 @@ public class TestFileLogging {
 
   @AfterClass
   public static void cleanUp() throws Exception {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/CDAPLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/CDAPLogAppenderTest.java
@@ -110,14 +110,14 @@ public class CDAPLogAppenderTest {
     );
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass
   public static void cleanUp() {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/LogFileManagerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/appender/system/LogFileManagerTest.java
@@ -96,14 +96,14 @@ public class LogFileManagerTest {
     );
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
 
     StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass
   public static void cleanUp() {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/FileMetadataCleanerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/FileMetadataCleanerTest.java
@@ -108,13 +108,13 @@ public class FileMetadataCleanerTest {
     );
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass
   public static void cleanUp() {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/LogCleanerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/clean/LogCleanerTest.java
@@ -109,13 +109,13 @@ public class LogCleanerTest {
     );
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass
   public static void cleanUp() {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/framework/distributed/DistributedLogFrameworkTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/framework/distributed/DistributedLogFrameworkTest.java
@@ -112,19 +112,19 @@ public class DistributedLogFrameworkTest {
   @Before
   public void beforeTest() throws Exception {
     injector = createInjector();
-    injector.getInstance(ZKClientService.class).startAndWait();
-    injector.getInstance(KafkaClientService.class).startAndWait();
-    injector.getInstance(BrokerService.class).startAndWait();
-    injector.getInstance(TransactionManager.class).startAndWait();
+    injector.getInstance(ZKClientService.class).startAsync().awaitRunning();
+    injector.getInstance(KafkaClientService.class).startAsync().awaitRunning();
+    injector.getInstance(BrokerService.class).startAsync().awaitRunning();
+    injector.getInstance(TransactionManager.class).startAsync().awaitRunning();
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @After
   public void afterTest() {
-    injector.getInstance(TransactionManager.class).stopAndWait();
-    injector.getInstance(BrokerService.class).stopAndWait();
-    injector.getInstance(KafkaClientService.class).stopAndWait();
-    injector.getInstance(ZKClientService.class).stopAndWait();
+    injector.getInstance(TransactionManager.class).stopAsync().awaitTerminated();
+    injector.getInstance(BrokerService.class).stopAsync().awaitTerminated();
+    injector.getInstance(KafkaClientService.class).stopAsync().awaitTerminated();
+    injector.getInstance(ZKClientService.class).stopAsync().awaitTerminated();
     injector = null;
   }
 
@@ -133,7 +133,7 @@ public class DistributedLogFrameworkTest {
     DistributedLogFramework framework = injector.getInstance(DistributedLogFramework.class);
     CConfiguration cConf = injector.getInstance(CConfiguration.class);
 
-    framework.startAndWait();
+    framework.startAsync().awaitRunning();
 
     // Send some logs to Kafka.
     LoggingContext context = new ServiceLoggingContext(NamespaceId.SYSTEM.getNamespace(),
@@ -186,7 +186,7 @@ public class DistributedLogFrameworkTest {
       }
     }, 10, TimeUnit.SECONDS, msgCount, TimeUnit.MILLISECONDS);
 
-    framework.stopAndWait();
+    framework.stopAsync().awaitTerminated();
 
     String kafkaTopic = cConf.get(Constants.Logging.KAFKA_TOPIC);
     // Check the checkpoint is persisted correctly. Since all messages are processed,

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/ConcurrentLogBufferWriterTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/ConcurrentLogBufferWriterTest.java
@@ -81,7 +81,7 @@ public class ConcurrentLogBufferWriterTest {
       new LogProcessorPipelineContext(CConfiguration.create(), "test", loggerContext, NO_OP_METRICS_CONTEXT, 0),
       config, checkpointManager, 0);
     // start the pipeline
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     ConcurrentLogBufferWriter writer = new ConcurrentLogBufferWriter(cConf, ImmutableList.of(pipeline), () -> { });
     ImmutableList<byte[]> events = getLoggingEvents();
@@ -97,7 +97,7 @@ public class ConcurrentLogBufferWriterTest {
 
     // verify if the pipeline has processed the messages.
     Tasks.waitFor(5, () -> appender.getEvents().size(), 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    pipeline.stopAndWait();
+    pipeline.stopAsync().awaitTerminated();
     loggerContext.stop();
   }
 
@@ -122,7 +122,7 @@ public class ConcurrentLogBufferWriterTest {
       new LogProcessorPipelineContext(CConfiguration.create(), "test", loggerContext, NO_OP_METRICS_CONTEXT, 0),
       config, checkpointManager, 0);
     // start the pipeline
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     ConcurrentLogBufferWriter writer = new ConcurrentLogBufferWriter(cConf, ImmutableList.of(pipeline), () -> { });
     ImmutableList<byte[]> events = getLoggingEvents();
@@ -156,7 +156,7 @@ public class ConcurrentLogBufferWriterTest {
 
     // verify if the pipeline has processed the messages.
     Tasks.waitFor(100, () -> appender.getEvents().size(), 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
-    pipeline.stopAndWait();
+    pipeline.stopAsync().awaitTerminated();
     loggerContext.stop();
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/handler/LogBufferHandlerTest.java
@@ -73,7 +73,7 @@ public class LogBufferHandlerTest {
                                       "Test", MockAppender.class);
 
     LogBufferProcessorPipeline pipeline = getLogPipeline(loggerContext);
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     ConcurrentLogBufferWriter writer = new ConcurrentLogBufferWriter(cConf, ImmutableList.of(pipeline), () -> { });
 
@@ -98,7 +98,7 @@ public class LogBufferHandlerTest {
 
     remoteLogAppender.stop();
     httpService.stop();
-    pipeline.stopAndWait();
+    pipeline.stopAsync().awaitTerminated();
     loggerContext.stop();
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/recover/LogBufferRecoveryServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/logbuffer/recover/LogBufferRecoveryServiceTest.java
@@ -72,7 +72,7 @@ public class LogBufferRecoveryServiceTest {
       config, checkpointManager, 0);
 
     // start the pipeline
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     // write directly to log buffer
     LogBufferWriter writer = new LogBufferWriter(absolutePath, 250, () -> { });
@@ -85,12 +85,12 @@ public class LogBufferRecoveryServiceTest {
     LogBufferRecoveryService service = new LogBufferRecoveryService(ImmutableList.of(pipeline),
                                                                     ImmutableList.of(checkpointManager),
                                                                     absolutePath, 2, new AtomicBoolean(true));
-    service.startAndWait();
+    service.startAsync().awaitRunning();
 
     Tasks.waitFor(5, () -> appender.getEvents().size(), 120, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
-    service.stopAndWait();
-    pipeline.stopAndWait();
+    service.stopAsync().awaitTerminated();
+    pipeline.stopAsync().awaitTerminated();
     loggerContext.stop();
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/pipeline/kafka/KafkaLogProcessorPipelineTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/pipeline/kafka/KafkaLogProcessorPipelineTest.java
@@ -134,7 +134,7 @@ public class KafkaLogProcessorPipelineTest {
       checkpointManager,
       KAFKA_TESTER.getBrokerService(), config);
 
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     // Publish some log messages to Kafka
     long now = System.currentTimeMillis();
@@ -176,7 +176,7 @@ public class KafkaLogProcessorPipelineTest {
       Assert.assertEquals("Large logger " + i, events.get(i).getMessage());
     }
 
-    pipeline.stopAndWait();
+    pipeline.stopAsync().awaitTerminated();
     loggerContext.stop();
 
     Assert.assertNull(appender.getEvents());
@@ -203,7 +203,7 @@ public class KafkaLogProcessorPipelineTest {
       checkpointManager,
       KAFKA_TESTER.getBrokerService(), config);
 
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     // Even when there is no event, the flush should still get called.
     Tasks.waitFor(5, appender::getFlushCount, 3, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
@@ -219,7 +219,7 @@ public class KafkaLogProcessorPipelineTest {
     // Wait until getting all logs.
     Tasks.waitFor(3, () -> appender.getEvents().size(), 3, TimeUnit.SECONDS, 200, TimeUnit.MILLISECONDS);
 
-    pipeline.stopAndWait();
+    pipeline.stopAsync().awaitTerminated();
 
     // Should get at least 20 flush calls, since the checkpoint is every 2 seconds
     Assert.assertTrue(appender.getFlushCount() >= 20);
@@ -229,7 +229,7 @@ public class KafkaLogProcessorPipelineTest {
   public void testMetricsAppender() throws Exception {
     Injector injector = KAFKA_TESTER.getInjector();
     MetricsCollectionService collectionService = injector.getInstance(MetricsCollectionService.class);
-    collectionService.startAndWait();
+    collectionService.startAsync().awaitRunning();
     LoggerContext loggerContext = new LocalAppenderContext(injector.getInstance(TransactionRunner.class),
                                                            injector.getInstance(LocationFactory.class),
                                                            injector.getInstance(MetricsCollectionService.class));
@@ -254,7 +254,7 @@ public class KafkaLogProcessorPipelineTest {
       checkpointManager,
       KAFKA_TESTER.getBrokerService(), config);
 
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     // Publish some log messages to Kafka
     long now = System.currentTimeMillis();
@@ -337,9 +337,9 @@ public class KafkaLogProcessorPipelineTest {
                                                  LoggingContextHelper.getMetricsTags(serviceLoggingContext),
                                                  new ArrayList<>()), 3L);
     } finally {
-      pipeline.stopAndWait();
+      pipeline.stopAsync().awaitTerminated();
       loggerContext.stop();
-      collectionService.stopAndWait();
+      collectionService.stopAsync().awaitTerminated();
     }
   }
 
@@ -379,7 +379,7 @@ public class KafkaLogProcessorPipelineTest {
       checkpointManager,
       KAFKA_TESTER.getBrokerService(), config);
 
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     // Publish some log messages to Kafka using a non-specific logger
     long now = System.currentTimeMillis();
@@ -439,7 +439,7 @@ public class KafkaLogProcessorPipelineTest {
       return Arrays.asList("TRACE", "DEBUG", "INFO", "WARN", "ERROR", "ERROR").equals(lines1);
     }, 5, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
 
-    pipeline.stopAndWait();
+    pipeline.stopAsync().awaitTerminated();
     loggerContext.stop();
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipelineTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/pipeline/logbuffer/LogBufferProcessorPipelineTest.java
@@ -67,7 +67,7 @@ public class LogBufferProcessorPipelineTest {
       new LogProcessorPipelineContext(CConfiguration.create(), "test", loggerContext, NO_OP_METRICS_CONTEXT, 0),
       config, checkpointManager, 0);
     // start the pipeline
-    pipeline.startAndWait();
+    pipeline.startAsync().awaitRunning();
 
     // start thread to write to incomingEventQueue
     List<ILoggingEvent> events = getLoggingEvents();
@@ -95,7 +95,7 @@ public class LogBufferProcessorPipelineTest {
     // wait for pipeline to append all the logs to appender. The DEBUG message should get filtered out.
     Tasks.waitFor(200, () -> appender.getEvents().size(), 60, TimeUnit.SECONDS, 100, TimeUnit.MILLISECONDS);
     executorService.shutdown();
-    pipeline.stopAndWait();
+    pipeline.stopAsync().awaitTerminated();
     loggerContext.stop();
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/plugins/RollingLocationLogAppenderTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/plugins/RollingLocationLogAppenderTest.java
@@ -110,12 +110,12 @@ public class RollingLocationLogAppenderTest {
     );
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
   }
 
   @AfterClass
   public static void cleanUp() throws Exception {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/logging/read/FileMetadataTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/logging/read/FileMetadataTest.java
@@ -99,13 +99,13 @@ public class FileMetadataTest {
     );
 
     txManager = injector.getInstance(TransactionManager.class);
-    txManager.startAndWait();
+    txManager.startAsync().awaitRunning();
     StoreDefinition.LogFileMetaStore.create(injector.getInstance(StructuredTableAdmin.class));
   }
 
   @AfterClass
   public static void cleanUp() {
-    txManager.stopAndWait();
+    txManager.stopAsync().awaitTerminated();
   }
 
   @Test

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/MetricsTestBase.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/MetricsTestBase.java
@@ -82,7 +82,7 @@ public abstract class MetricsTestBase {
     injector = Guice.createInjector(getModules());
     messagingService = injector.getInstance(MessagingService.class);
     if (messagingService instanceof Service) {
-      ((Service) messagingService).startAndWait();
+      ((Service) messagingService).startAsync().awaitRunning();
     }
     metricValueType = TypeToken.of(MetricValues.class);
     schema = new ReflectionSchemaGenerator().generate(metricValueType.getType());
@@ -93,7 +93,7 @@ public abstract class MetricsTestBase {
   @After
   public void stop() {
     if (messagingService instanceof Service) {
-      ((Service) messagingService).stopAndWait();
+      ((Service) messagingService).stopAsync().awaitTerminated();
     }
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/AggregatedMetricsCollectionServiceTest.java
@@ -74,7 +74,7 @@ public class AggregatedMetricsCollectionServiceTest {
       }
     };
 
-    service.startAndWait();
+    service.startAsync().awaitRunning();
 
     // non-empty tags.
     final Map<String, String> baseTags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NAMESPACE,
@@ -139,7 +139,7 @@ public class AggregatedMetricsCollectionServiceTest {
       metricsContext.gauge(GAUGE_METRIC, 0);
       verifyCounterMetricsValue(published, ImmutableMap.of(6, ImmutableMap.of(GAUGE_METRIC, 0L)));
     } finally {
-      service.stopAndWait();
+      service.stopAsync().awaitTerminated();
     }
   }
 
@@ -211,7 +211,7 @@ public class AggregatedMetricsCollectionServiceTest {
       }
     };
 
-    service.startAndWait();
+    service.startAsync().awaitRunning();
 
     // non-empty tags.
     final Map<String, String> baseTags = ImmutableMap.of(Constants.Metrics.Tag.NAMESPACE, NAMESPACE,
@@ -245,7 +245,7 @@ public class AggregatedMetricsCollectionServiceTest {
       verifyDistribtionMetricValues(published, 2, 4);
 
     } finally {
-      service.stopAndWait();
+      service.stopAsync().awaitTerminated();
     }
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/MessagingMetricsCollectionServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/collect/MessagingMetricsCollectionServiceTest.java
@@ -62,14 +62,14 @@ public class MessagingMetricsCollectionServiceTest extends MetricsTestBase {
     MetricsCollectionService collectionService = new MessagingMetricsCollectionService(CConfiguration.create(),
                                                                                        messagingService,
                                                                                        recordWriter);
-    collectionService.startAndWait();
+    collectionService.startAsync().awaitRunning();
 
     // publish metrics for different context
     for (int i = 1; i <= 3; i++) {
       collectionService.getContext(ImmutableMap.of("tag", "" + i)).increment("processed", i);
     }
 
-    collectionService.stopAndWait();
+    collectionService.stopAsync().awaitTerminated();
 
     // <Context, metricName, value>
     Table<String, String, Long> expected = HashBasedTable.create();

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MessagingMetricsProcessorManagerServiceTest.java
@@ -68,10 +68,10 @@ public class MessagingMetricsProcessorManagerServiceTest extends MetricsProcesso
   @Test
   public void persistMetricsTests() throws Exception {
 
-    injector.getInstance(TransactionManager.class).startAndWait();
+    injector.getInstance(TransactionManager.class).startAsync().awaitRunning();
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
-    injector.getInstance(DatasetOpExecutorService.class).startAndWait();
-    injector.getInstance(DatasetService.class).startAndWait();
+    injector.getInstance(DatasetOpExecutorService.class).startAsync().awaitRunning();
+    injector.getInstance(DatasetService.class).startAsync().awaitRunning();
 
     Set<Integer> partitions = IntStream.range(0, cConf.getInt(Constants.Metrics.MESSAGING_TOPIC_NUM))
       .boxed().collect(Collectors.toSet());
@@ -106,7 +106,7 @@ public class MessagingMetricsProcessorManagerServiceTest extends MetricsProcesso
                                                     injector.getInstance(DatumReaderFactory.class), metricStore,
                                                     injector.getInstance(MetricsWriterProvider.class),
                                                     partitions, new NoopMetricsContext(), 50, 0);
-      messagingMetricsProcessorManagerService.startAndWait();
+      messagingMetricsProcessorManagerService.startAsync().awaitRunning();
 
       // Wait for the 1 aggregated counter metric (with value 50) and 50 gauge metrics to be stored in the metricStore
       Tasks.waitFor(51, () -> metricStore.getAllCounterAndGaugeMetrics().size(), 15,
@@ -139,7 +139,7 @@ public class MessagingMetricsProcessorManagerServiceTest extends MetricsProcesso
       metricStore.deleteAll();
       expected.clear();
       // Stop messagingMetricsProcessorManagerService
-      messagingMetricsProcessorManagerService.stopAndWait();
+      messagingMetricsProcessorManagerService.stopAsync().awaitTerminated();
     }
   }
 

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsAdminSubscriberServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsAdminSubscriberServiceTest.java
@@ -116,25 +116,25 @@ public class MetricsAdminSubscriberServiceTest {
     metricsQueryService = injector.getInstance(MetricsQueryService.class);
 
     if (messagingService instanceof Service) {
-      ((Service) messagingService).startAndWait();
+      ((Service) messagingService).startAsync().awaitRunning();
     }
-    metricsCollectionService.startAndWait();
-    metricsQueryService.startAndWait();
+    metricsCollectionService.startAsync().awaitRunning();
+    metricsQueryService.startAsync().awaitRunning();
   }
 
   @AfterClass
   public static void finish() {
-    metricsQueryService.stopAndWait();
-    metricsCollectionService.stopAndWait();
+    metricsQueryService.stopAsync().awaitTerminated();
+    metricsCollectionService.stopAsync().awaitTerminated();
     if (messagingService instanceof Service) {
-      ((Service) messagingService).stopAndWait();
+      ((Service) messagingService).stopAsync().awaitTerminated();
     }
   }
 
   @Test
   public void test() throws Exception {
     MetricsAdminSubscriberService adminService = injector.getInstance(MetricsAdminSubscriberService.class);
-    adminService.startAndWait();
+    adminService.startAsync().awaitRunning();
 
     // publish a metrics
     MetricsContext metricsContext = metricsCollectionService.getContext(
@@ -222,6 +222,6 @@ public class MetricsAdminSubscriberServiceTest {
       return !foundInc && !foundGauge;
     }, 1000, TimeUnit.SECONDS, 1, TimeUnit.SECONDS);
 
-    adminService.stopAndWait();
+    adminService.stopAsync().awaitTerminated();
   }
 }

--- a/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsProcessorServiceTest.java
+++ b/cdap-watchdog/src/test/java/io/cdap/cdap/metrics/process/MetricsProcessorServiceTest.java
@@ -59,10 +59,10 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
 
   @Test
   public void testMetricsProcessor() throws Exception {
-    injector.getInstance(TransactionManager.class).startAndWait();
+    injector.getInstance(TransactionManager.class).startAsync().awaitRunning();
     StoreDefinition.createAllTables(injector.getInstance(StructuredTableAdmin.class));
-    injector.getInstance(DatasetOpExecutorService.class).startAndWait();
-    injector.getInstance(DatasetService.class).startAndWait();
+    injector.getInstance(DatasetOpExecutorService.class).startAsync().awaitRunning();
+    injector.getInstance(DatasetService.class).startAsync().awaitRunning();
 
     final MetricStore metricStore = injector.getInstance(MetricStore.class);
 
@@ -81,7 +81,7 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
                                                   injector.getInstance(DatumReaderFactory.class),
                                                   metricStore, injector.getInstance(MetricsWriterProvider.class),
                                                   partitions, new NoopMetricsContext(), 50, 0);
-    messagingMetricsProcessorManagerService.startAndWait();
+    messagingMetricsProcessorManagerService.startAsync().awaitRunning();
 
     long startTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
     // Publish metrics with messaging service and record expected metrics
@@ -91,7 +91,7 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
 
     Thread.sleep(500);
     // Stop and restart messagingMetricsProcessorManagerService
-    messagingMetricsProcessorManagerService.stopAndWait();
+    messagingMetricsProcessorManagerService.stopAsync().awaitTerminated();
     // Intentionally set queue size to a large value, so that MessagingMetricsProcessorManagerService
     // internally only persists metrics during terminating.
     messagingMetricsProcessorManagerService =
@@ -100,7 +100,7 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
                                                   injector.getInstance(DatumReaderFactory.class),
                                                   metricStore, injector.getInstance(MetricsWriterProvider.class),
                                                   partitions, new NoopMetricsContext(), 50, 0);
-    messagingMetricsProcessorManagerService.startAndWait();
+    messagingMetricsProcessorManagerService.startAsync().awaitRunning();
 
     // Publish metrics after MessagingMetricsProcessorManagerService restarts and record expected metrics
     for (int i = 20; i < 30; i++) {
@@ -138,7 +138,7 @@ public class MetricsProcessorServiceTest extends MetricsProcessorServiceTestBase
     }
 
     // Stop services and servers
-    messagingMetricsProcessorManagerService.stopAndWait();
+    messagingMetricsProcessorManagerService.stopAsync().awaitTerminated();
     // Delete all metrics
     metricStore.deleteAll();
   }


### PR DESCRIPTION
Upgrade Guava library to version 32.0.0-jre in CDAP Watchdog and the modules it depends on.

- Updated the Guava dependency version in `pom.xml` to 32.0.0-jre.
- Addressed compatibility issues with the upgraded Guava version.